### PR TITLE
Fix store scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stores no longer return `this` from `register()` by default. **This is
   a potentially breaking change**, however should not pose a problem to
   projects using idiomatic Store registration.
+- Scope of store reducers when dispatching will always be the Store
 
 ### Internal Changes
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -25,7 +25,7 @@ Store.prototype = {
 
   send(state, action, params) {
     let task  = this.register()[action]
-    return task? task(state, params) : state
+    return task? task.call(this, state, params) : state
   }
 }
 

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -7,4 +7,18 @@ describe('Store', function() {
     store.toString().should.equal('sample')
   })
 
+  it ('always sends actions in the context of the store', function() {
+    let store = new Store({
+      register() {
+        return {
+          test() {
+            return this
+          }
+        }
+      }
+    }, 'sample')
+
+    store.send({}, 'test', {}).should.equal(store)
+  })
+
 })


### PR DESCRIPTION
cc @averyvery 

This PR makes all dispatched store actions be called within the scope of the store itself.