### PR TITLE
Store refactor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,6 @@
   "loose": true,
   "sourceMaps": "inline",
   "blacklist" : [ "strict" ],
-  "optional"  : []
+  "optional"  : [],
+  "plugins": [ "object-assign" ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 8.2.0
+
+## Internal Changes
+
+- Upgrade Foliage to `0.21.0`.
+- Moved `Store.prototype.send` to `Store.send`. This has always been
+  an internal API, however those using this method for testing will
+  need to update. This change is motivated by a desire to reduce as
+  much surface area from Store instances as possible.
+- We now use `babel-plugin-object-assign` for extension
+
+## Upgrading
+
+For those using `Store.prototype.send`, the following change is
+necessary:
+
+```javascript
+// Before
+store.send(state, action, payload)
+//After
+Store.send(action, store, state, payload)
+```
+
 ## 8.1.0
 
 ### Noticeable changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ necessary:
 // Before
 store.send(state, action, payload)
 //After
-Store.send(action, store, state, payload)
+Store.send(store, action, state, payload)
 ```
 
 ## 8.1.0

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-object-assign": "^1.1.0",
     "foliage": "~0.21.0"
   },
   "devDependencies": {

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -199,7 +199,7 @@ Microcosm.prototype = Object.assign({}, Foliage.prototype, {
       let state = this.get(key)
       let store = this.stores[key]
 
-      this.set(key, Store.send(action, store, state, payload))
+      this.set(key, Store.send(store, action, state, payload))
     }
 
     return payload

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -19,8 +19,7 @@ function Microcosm() {
   this.plugins = []
 }
 
-Microcosm.prototype = {
-  ...Foliage.prototype,
+Microcosm.prototype = Object.assign({}, Foliage.prototype, {
 
   /**
    * Generates the initial state a microcosm starts with. The reduction
@@ -200,13 +199,12 @@ Microcosm.prototype = {
       let state = this.get(key)
       let store = this.stores[key]
 
-      this.set(key, store.send(state, action, payload))
-      this.volley()
+      this.set(key, Store.send(action, store, state, payload))
     }
 
     return payload
   }
 
-}
+})
 
 module.exports = Microcosm

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,9 +1,7 @@
 let uid = 0
 
 function Plugin(config, options) {
-  for (var i in config) {
-    this[i] = config[i]
-  }
+  Object.assign(this, config)
 
   this.name    = this.name || 'microcosm_plugin_' + uid++
   this.options = options

--- a/src/Store.js
+++ b/src/Store.js
@@ -4,13 +4,10 @@
  */
 
 let identity = i => i
+let isDev    = process.env.NODE_ENV !== 'production'
 
 function Store (config, id) {
-  // Fold configuration over self
-  for (var i in config) {
-    this[i] = config[i]
-  }
-
+  Object.assign(this, config)
   this.toString = () => id
 }
 
@@ -21,12 +18,18 @@ Store.prototype = {
 
   register() {
     return {}
-  },
-
-  send(state, action, params) {
-    let task  = this.register()[action]
-    return task? task.call(this, state, params) : state
   }
+}
+
+Store.send = function (action, store, state, params) {
+  let tasks = store.register()
+  let task  = tasks[action]
+
+  if (isDev && action in tasks && typeof task !== 'function') {
+    throw TypeError(`${ store } registered ${ action } with non-function value`)
+  }
+
+  return task ? task.call(store, state, params) : state
 }
 
 module.exports = Store

--- a/src/Store.js
+++ b/src/Store.js
@@ -21,7 +21,7 @@ Store.prototype = {
   }
 }
 
-Store.send = function (action, store, state, params) {
+Store.send = function (store, action, state, params) {
   let tasks = store.register()
   let task  = tasks[action]
 

--- a/src/__tests__/Microcosm-test.js
+++ b/src/__tests__/Microcosm-test.js
@@ -100,6 +100,33 @@ describe('Microcosm', function() {
 
   })
 
+  describe('::addStore', function() {
+    it ('throws an error if no key is given', function(done) {
+      try {
+        new Microcosm().addStore({})
+      } catch(x) {
+        x.should.be.instanceOf(TypeError)
+        done()
+      }
+    })
+  })
+
+  describe('::toObject', function() {
+    it ('aliases valueOf', function() {
+      sinon.spy(app, 'valueOf')
+      app.toObject()
+      app.valueOf.should.have.been.called
+    })
+  })
+
+  describe('::prepare', function() {
+    it ('binds arguments to push', function() {
+      sinon.stub(app, 'push')
+      app.prepare('action', 1, 2)(3)
+      app.push.should.have.been.calledWith('action', 1, 2, 3)
+    })
+  })
+
   describe('::dispatch', function() {
     let local;
 

--- a/src/__tests__/Microcosm-test.js
+++ b/src/__tests__/Microcosm-test.js
@@ -105,12 +105,16 @@ describe('Microcosm', function() {
 
     beforeEach(function(done) {
       local = new Microcosm()
-      local.addStore('another-store', { respond: () => true })
+      local.addStore('another-store', {
+        register() {
+          return { respond: () => true }
+        }
+      })
       local.start(done)
     })
 
     it ('commits changes if a store can respond', function(done) {
-      local.listen(done)
+      local.listen(_ => done())
       local.dispatch('respond')
     })
 

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -18,7 +18,22 @@ describe('Store', function() {
       }
     }, 'sample')
 
-    store.send({}, 'test', {}).should.equal(store)
+    Store.send('test', store).should.equal(store)
+  })
+
+  it ('validates that handlers are functions', function(done) {
+    let store = {
+      register() {
+        return { test: null }
+      }
+    }
+
+    try {
+      Store.send('test', store)
+    } catch(x) {
+      x.should.be.instanceOf(TypeError)
+      done()
+    }
   })
 
 })

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -18,7 +18,7 @@ describe('Store', function() {
       }
     }, 'sample')
 
-    Store.send('test', store).should.equal(store)
+    Store.send(store, 'test').should.equal(store)
   })
 
   it ('validates that handlers are functions', function(done) {
@@ -29,7 +29,7 @@ describe('Store', function() {
     }
 
     try {
-      Store.send('test', store)
+      Store.send(store, 'test')
     } catch(x) {
       x.should.be.instanceOf(TypeError)
       done()

--- a/src/__tests__/run-test.js
+++ b/src/__tests__/run-test.js
@@ -1,0 +1,11 @@
+import run from '../run'
+
+describe('run', function() {
+  it ('throws an error if callbacks are not functions', function(done) {
+    try {
+      run([ null ])
+    } catch(x) {
+      done()
+    }
+  })
+})


### PR DESCRIPTION
This is mostly internal changes. However it highlights the beginning of trying to reduce the surface area of stores.

The biggest change here is how Stores accept actions:

```javascript
// Before
store.send(state, action, payload)
//After
Store.send(store, action, state, payload)
```

So now, this is a static method of `Store`. `send` is no longer on the prototype.

---

Summary of work:

1. Upgrade Foliage to 0.21.0
2. Move Store.prototype.send to Store.send. Change function signature to align more with other methods
3. Add `babel-plugin-object-assign` so that Object.assign can be used under the hood (transpiled polyfill)

