### PR TITLE
v9.x callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "diode": "~4.4",
-    "is-promise": "^2.1",
+    "is-promise": "^2.0",
     "is-generator": "^1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "diode": "~4.4",
-    "is-promise": "~2.0",
-    "is-generator": "~1.0"
+    "is-promise": "^2.1",
+    "is-generator": "^1.0"
   },
   "devDependencies": {
     "autoprefixer-core": "~5.2",

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -134,8 +134,8 @@ Microcosm.prototype = {
    * Clear all outstanding transactions and assign base state
    * to a given object (or getInitialState())
    */
-  reset(state=this.getInitialState(), transactions=[]) {
-    this.transactions = transactions
+  reset(state=this.getInitialState()) {
+    this.transactions = []
     this.base = state
 
     return this.transact()

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -107,8 +107,8 @@ Microcosm.prototype = {
   /**
    * Partially applies `push`.
    */
-  prepare(action, ...params) {
-    return this.push.bind(this, action, ...params)
+  prepare(action, params) {
+    return (more, callback) => this.push(action, [].concat(params, more), callback)
   },
 
   /**
@@ -116,12 +116,12 @@ Microcosm.prototype = {
    * a unique transaction. If an error occurs, it will mark it for clean up
    * and the change will disappear from history.
    */
-  push(action, ...params) {
+  push(action, params, callback) {
     if (process.env.NODE_ENV !== 'production' && typeof action !== 'function') {
       throw TypeError(`Tried to push ${ action }, but is not a function.`)
     }
 
-    let transaction = new Transaction(action, params, this.transact.bind(this))
+    let transaction = new Transaction(action, params, callback)
 
     transaction.listen(this.transact.bind(this))
 

--- a/src/__tests__/Microcosm-test.js
+++ b/src/__tests__/Microcosm-test.js
@@ -38,8 +38,8 @@ describe('Microcosm', function() {
 
   it ('binds arguments to push', function() {
     sinon.stub(app, 'push')
-    app.prepare('action', 1, 2)(3)
-    app.push.should.have.been.calledWith('action', 1, 2, 3)
+    app.prepare('action', [ 1, 2 ])(3)
+    app.push.should.have.been.calledWith('action', [ 1, 2, 3 ])
   })
 
   it ('throws an error if asked to push a non-function value', function(done) {

--- a/src/__tests__/dispatch-generator-test.js
+++ b/src/__tests__/dispatch-generator-test.js
@@ -38,10 +38,9 @@ describe('When dispatching generators', function() {
       }
     })
 
-    app.start()
-    app.push(multiple, 2)
-
-    app.state.test.should.equal(3)
+    app.start().push(multiple, 2, function() {
+      app.state.test.should.equal(3)
+    })
   })
 
   it ('waits for all promises in the chain to resolve', function(done) {
@@ -59,9 +58,7 @@ describe('When dispatching generators', function() {
       }
     })
 
-    app.start()
-
-    app.push(resolve, 2).done(function() {
+    app.start().push(resolve, 2, function() {
       app.state.test.should.equal(3)
       done()
     })

--- a/src/__tests__/dispatch-primitive-test.js
+++ b/src/__tests__/dispatch-primitive-test.js
@@ -18,9 +18,9 @@ describe('When dispatching primitive values', function() {
   })
 
   it ('properly reduces from a store', function(done) {
-    app.listen(function() {
+    app.push(add, 2, function() {
       app.state.test.should.equal(app.stores.test.getInitialState() + 2)
       done()
-    }).push(add, 2)
+    })
   })
 })

--- a/src/__tests__/dispatch-promise-test.js
+++ b/src/__tests__/dispatch-promise-test.js
@@ -43,7 +43,7 @@ describe('When dispatching promises', function() {
     app.start(done)
   })
 
-  it ('waits for the promise to resolve', function(done) {
+  it ('returns the promise from app.push', function(done) {
     app.push(single, 2).done(function() {
       app.state.test.should.equal(3)
       done()
@@ -52,22 +52,21 @@ describe('When dispatching promises', function() {
 
   it ('does not dispatch if the promise fails', function(done) {
     sinon.spy(app, 'dispatch')
-
-    app.push(error).done(null, function() {
+    app.push(error, [], function() {
       app.dispatch.should.not.have.been.called
       done()
     })
   })
 
   it ('waits for all promises in the chain to resolve', function(done) {
-    app.push(chain, 1).done(function() {
+    app.push(chain, 1, function() {
       app.state.test.should.equal(2)
       done()
     })
   })
 
   it ('respects future changes when it fails', function(done) {
-    app.push(error, 1).done(null, function() {
+    app.push(error, 1, function() {
       app.state.test.should.equal(5)
       done()
     })
@@ -78,7 +77,7 @@ describe('When dispatching promises', function() {
   it ('does not dispatch transactions for unresolved promises', function(done) {
     let spy = sinon.spy(TestStore, 'sum')
 
-    app.push(late, 1).done(function() {
+    app.push(late, 1, function() {
       app.state.test.should.equal(6)
 
       // Twice for 'pass' and once for 'late'

--- a/src/chain.js
+++ b/src/chain.js
@@ -1,0 +1,17 @@
+/**
+ * Chain generator calls using nodeify
+ */
+
+let nodeify = require('./nodeify')
+
+module.exports = function chain (iterator, callback) {
+
+  return nodeify(iterator.next().value, function step (error, body) {
+
+    let { value, done } = iterator.next()
+
+    callback(error, body, !done)
+
+    return error || done ? body : nodeify(value, step)
+  })
+}

--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -1,0 +1,24 @@
+/**
+ * Converts a promise into an error-first callback
+ */
+
+let isPromise = require('is-promise')
+
+const DEFAULT_ERROR = new Error('Rejected Promise')
+
+module.exports = function nodeify (promise, callback) {
+  // Loose check until this lands:
+  // https://github.com/then/is-promise/pull/3
+  if (!isPromise(promise)) {
+    return callback(null, promise)
+  }
+
+  return promise.then(function(body) {
+    callback(null, body)
+  }).catch(function(error) {
+    callback(error || DEFAULT_ERROR)
+
+    // Throw so future error handling can occur
+    throw error
+  })
+}

--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -7,8 +7,6 @@ let isPromise = require('is-promise')
 const DEFAULT_ERROR = new Error('Rejected Promise')
 
 module.exports = function nodeify (promise, callback) {
-  // Loose check until this lands:
-  // https://github.com/then/is-promise/pull/3
   if (!isPromise(promise)) {
     return callback(null, promise)
   }


### PR DESCRIPTION
`app.push` now conducts the following behavior:

```javascript
// app.push(action, arguments, callback)
app.push(action, [ 'one', 'two', 'three' ], function(error, body) {
  // error of failed iteration
  // body of last iteration
})
```

I also picked up a few tricks from https://github.com/then/promise to ensure errors that occur in the callback do not get trapped by promise chains.

Also... I refactored `signal.js`, it feels quite a bit cleaner