### PR TITLE
Refactor plugins for lifecycle methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "diode": "~4.4",
+    "diode": "~5.0",
     "is-promise": "^2.0",
     "is-generator": "^1.0"
   },

--- a/src/install.js
+++ b/src/install.js
@@ -8,10 +8,10 @@ function install (plugins, callback) {
     return callback(null)
   }
 
-  let Plugin = plugins[0]
-  let tail = plugins.slice(1)
+  let plugin = plugins[0]
+  let tail   = plugins.slice(1)
 
-  return new Plugin(function(err) {
+  return plugin.__start(function(err) {
     err ? callback(err) : install(tail, callback)
   })
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,20 +7,16 @@
  * of a Microcosm.
  */
 
-module.exports = function PluginFactory(config, options, app) {
-
-  let Plugin = function(callback) {
-    this.app = app
-    this.options = options
-
+const defaults = {
+  __start(callback) {
     this.register(this.app, this.options, callback)
+  },
+
+  register(app, options, next) {
+    next()
   }
+}
 
-  Plugin.prototype = config
-
-  if (process.env.NODE_ENV !== 'production' && typeof config.register !== 'function') {
-    throw new TypeError("Plugins must include a register method.")
-  }
-
-  return Plugin
+module.exports = function PluginFactory(config, options, app) {
+  return Object.assign({ app, options }, defaults, config)
 }


### PR DESCRIPTION
This is a change from an outstanding branch that adds lifecycle methods. Not much, but plugins were instantiated on `start` before, which is problematic for the `appWillStart` lifecycle method :).