### PR TITLE
Transaction refactor

### DIFF
--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -24,8 +24,8 @@ Plugins are inspired by the API provided by
 greater
 adherence to the Hapi API to help share code and provide consistency.
 
-At the moment, the only requirement is that plugins implement a
-`register` method:
+Plugins implement a `register` method that is called whenever an application is
+started:
 
 ```javascript
 let LazyPlugin = {

--- a/examples/simple-svg/index.jsx
+++ b/examples/simple-svg/index.jsx
@@ -11,8 +11,8 @@ app.addStore('circle', Circle)
 
 app.start(function () {
   requestAnimationFrame(function loop () {
-    requestAnimationFrame(loop)
     app.push(update)
+    requestAnimationFrame(loop)
   })
 
   React.render(<Microscope instance={ app }><Viget /></Microscope>,

--- a/examples/simple-svg/index.jsx
+++ b/examples/simple-svg/index.jsx
@@ -11,8 +11,8 @@ app.addStore('circle', Circle)
 
 app.start(function () {
   requestAnimationFrame(function loop () {
-    app.push(update)
     requestAnimationFrame(loop)
+    app.push(update)
   })
 
   React.render(<Microscope instance={ app }><Viget /></Microscope>,

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -7,8 +7,6 @@ let plugin = require('./plugin')
 let remap = require('./remap')
 let tag = require('./tag')
 
-const EMPTY_ARRAY = []
-
 let Microcosm = function() {
   /**
    * Microcosm uses Diode for event emission. Diode is an event emitter
@@ -150,7 +148,7 @@ Microcosm.prototype = {
    * Clear all outstanding transactions and assign base state
    * to a given object (or getInitialState())
    */
-  reset(state=this.getInitialState(), transactions=EMPTY_ARRAY) {
+  reset(state=this.getInitialState(), transactions=[]) {
     this.transactions = flatten(transactions)
     this.base = state
 

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -7,6 +7,8 @@ let plugin = require('./plugin')
 let remap = require('./remap')
 let tag = require('./tag')
 
+const EMPTY_ARRAY = []
+
 let Microcosm = function() {
   /**
    * Microcosm uses Diode for event emission. Diode is an event emitter
@@ -148,8 +150,8 @@ Microcosm.prototype = {
    * Clear all outstanding transactions and assign base state
    * to a given object (or getInitialState())
    */
-  reset(state=this.getInitialState(), transactions=[]) {
-    this.transactions = flatten(transactions)
+  reset(state=this.getInitialState(), transactions=EMPTY_ARRAY) {
+    this.transactions = flatten(transactions) // Prevent accidental mutation
     this.base = state
 
     return this.rollforward()

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -55,13 +55,6 @@ Microcosm.prototype = {
     return transaction.meta.done
   },
 
-  /**
-   * Used to determine if a transaction should be purged during `clean()`
-   */
-  shouldRejectTransaction(item) {
-    return item.error
-  },
-
   /*
    * Before dispatching, this function is called on every transaction
    */
@@ -70,12 +63,10 @@ Microcosm.prototype = {
   },
 
   /**
-   * Remove invalid transactions
+   * Remove a transactions
    */
-  reject(transaction) {
-    if (this.shouldRejectTransaction(transaction)) {
-      this.transactions.splice(this.transactions.indexOf(transaction), 1)
-    }
+  release(transaction) {
+    this.transactions.splice(this.transactions.indexOf(transaction), 1)
 
     this.rollforward()
   },
@@ -148,7 +139,7 @@ Microcosm.prototype = {
 
     this.transactions.push(transaction)
 
-    return Transaction.run(transaction, body, this.reconcile, this.reject, callback, this)
+    return Transaction.run(transaction, body, this.reconcile, this.release, callback, this)
   },
 
   /**

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -72,10 +72,12 @@ Microcosm.prototype = {
   /**
    * Remove invalid transactions
    */
-  clean(transaction) {
+  reject(transaction) {
     if (this.shouldRejectTransaction(transaction)) {
       this.transactions.splice(this.transactions.indexOf(transaction), 1)
     }
+
+    this.rollforward()
   },
 
   /**
@@ -146,7 +148,7 @@ Microcosm.prototype = {
 
     this.transactions.push(transaction)
 
-    return Transaction.run(transaction, body, this.reconcile, this.clean, callback, this)
+    return Transaction.run(transaction, body, this.reconcile, this.reject, callback, this)
   },
 
   /**

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -97,6 +97,8 @@ Microcosm.prototype = {
       this.state = next
       this.emit(this.state)
     }
+
+    return this
   },
 
   /**
@@ -147,7 +149,7 @@ Microcosm.prototype = {
    * to a given object (or getInitialState())
    */
   reset(state=this.getInitialState(), transactions=[]) {
-    this.transactions = transactions
+    this.transactions = flatten(transactions)
     this.base = state
 
     return this.rollforward()

--- a/src/Store.js
+++ b/src/Store.js
@@ -3,35 +3,22 @@
  * Used to provide default values for a store configuration
  */
 
-let attempt = require('./attempt')
-let tag     = require('./tag')
-
-let Store = {
-
-  getInitialState(store) {
-    return attempt(store, 'getInitialState')
-  },
-
-  serialize(store, state) {
-    return attempt(store, 'serialize', [ state ], state)
-  },
-
-  deserialize(store, state) {
-    return attempt(store, 'deserialize', [ state ], state)
-  },
-
-  register(store) {
-    return attempt(store, 'register', [], undefined, store)
-  },
-
-  send(store, state, transaction) {
-    let { action, body } = transaction
-
-    tag(action)
-
-    return attempt(Store.register(store), action.toString(), [ state, body ], state, store)
+exports.getInitialState = function (store) {
+  if ('getInitialState' in store) {
+    return store.getInitialState()
   }
-
 }
 
-module.exports = Store
+exports.serialize = function (store, state) {
+  return 'serialize' in store ? store.serialize(state) : state
+}
+
+exports.deserialize = function (store, raw) {
+  return 'deserialize' in store ? store.deserialize(raw) : raw
+}
+
+exports.send = function (store, state, { payload, type }) {
+  let handler = 'register' in store ? store.register()[type] : false
+
+  return handler ? handler.call(store, state, payload) : state
+}

--- a/src/Store.js
+++ b/src/Store.js
@@ -4,21 +4,19 @@
  */
 
 exports.getInitialState = function (store) {
-  if ('getInitialState' in store) {
-    return store.getInitialState()
-  }
+  return store.getInitialState? store.getInitialState() : undefined
 }
 
 exports.serialize = function (store, state) {
-  return 'serialize' in store ? store.serialize(state) : state
+  return store.serialize? store.serialize(state) : state
 }
 
 exports.deserialize = function (store, raw) {
-  return 'deserialize' in store ? store.deserialize(raw) : raw
+  return store.deserialize? store.deserialize(raw) : raw
 }
 
 exports.send = function (store, state, { payload, type }) {
-  let handler = 'register' in store ? store.register()[type] : false
+  let handler = store.register? store.register()[type] : false
 
   return handler ? handler.call(store, state, payload) : state
 }

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -1,3 +1,9 @@
+/**
+ * Transaction
+ * An account of what has happened. Follows the standard action specification here:
+ * https://github.com/acdlite/flux-standard-action
+ */
+
 let signal  = require('./signal')
 let flatten = require('./flatten')
 

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -6,7 +6,7 @@
 
 let signal = require('./signal')
 
-exports.create = function (type) {
+function create (type) {
   return {
     type,
     payload: null,
@@ -18,8 +18,8 @@ exports.create = function (type) {
   }
 }
 
-exports.run = function (transaction, body, update, reject, callback, scope) {
-  return signal(body, function (error, payload, done) {
+function run (transaction, body, update, reject, callback, scope) {
+  return signal(body, function updateTransaction (error, payload, done) {
     transaction.meta.active = true
     transaction.meta.done = done
 
@@ -39,3 +39,5 @@ exports.run = function (transaction, body, update, reject, callback, scope) {
     }
   })
 }
+
+module.exports = { run, create }

--- a/src/__tests__/Microcosm-test.js
+++ b/src/__tests__/Microcosm-test.js
@@ -1,7 +1,8 @@
-let Action     = require('./fixtures/Action')
-let DummyStore = require('./fixtures/DummyStore')
-let Microcosm  = require('../Microcosm')
-let Store      = require('../Store')
+let Action      = require('./fixtures/Action')
+let DummyStore  = require('./fixtures/DummyStore')
+let Microcosm   = require('../Microcosm')
+let Store       = require('../Store')
+let Transaction = require('../Transaction')
 
 describe('Microcosm', function() {
   let app;
@@ -21,6 +22,19 @@ describe('Microcosm', function() {
     }
 
     new MyApp().stores.should.have.property('foo')
+  })
+
+  describe('reset', function() {
+    let dummy = Transaction.create('test')
+    let transactions = [dummy]
+
+    it ('can reset with specific transactions', function() {
+      app.reset({}, transactions).transactions.should.eql([dummy])
+    })
+
+    it ('copies the array when given transactions on reset', function() {
+      app.reset({}, transactions).transactions.should.not.equal(transactions)
+    })
   })
 
   it ('deserializes when replace is invoked', function(done) {
@@ -44,7 +58,7 @@ describe('Microcosm', function() {
 
   it ('prepare handles cases with no arguments', function() {
     sinon.stub(app, 'push')
-    
+
     app.prepare('action')(3)
     app.push.should.have.been.calledWith('action', [ 3 ])
 
@@ -57,6 +71,15 @@ describe('Microcosm', function() {
       app.push(null)
     } catch(x) {
       x.should.be.instanceof(TypeError)
+      done()
+    }
+  })
+
+  it ('throws an error if no key is given in addStore', function(done) {
+    try {
+      new Microcosm().addStore({})
+    } catch(x) {
+      x.should.be.instanceOf(TypeError)
       done()
     }
   })

--- a/src/attempt.js
+++ b/src/attempt.js
@@ -1,3 +1,0 @@
-module.exports = function attempt (obj, key, args, fallback, scope) {
-  return obj && obj[key] ? obj[key].apply(scope || obj, args) : fallback
-}

--- a/src/chain.js
+++ b/src/chain.js
@@ -5,12 +5,10 @@
 let nodeify = require('./nodeify')
 
 module.exports = function chain (iterator, callback) {
-
   return nodeify(iterator.next().value, function step (error, body) {
-
     let { value, done } = iterator.next()
 
-    callback(error, body, !done)
+    callback(error, body, done)
 
     return error || done ? body : nodeify(value, step)
   })

--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -8,13 +8,13 @@ const DEFAULT_ERROR = new Error('Rejected Promise')
 
 module.exports = function nodeify (promise, callback) {
   if (!isPromise(promise)) {
-    return callback(null, promise)
+    return callback(null, promise, true)
   }
 
   return promise.then(function(body) {
-    callback(null, body)
+    callback(null, body, true)
   }).catch(function(error) {
-    callback(error || DEFAULT_ERROR)
+    callback(error || DEFAULT_ERROR, null, true)
 
     // Throw so future error handling can occur
     throw error

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,7 +13,7 @@ const defaults = {
   },
 
   register(app, options, next) {
-    next()
+    next(null)
   }
 }
 

--- a/src/remap.js
+++ b/src/remap.js
@@ -7,7 +7,7 @@
  * @return Object
  */
 
-module.exports = function (obj, transform, scope) {
+module.exports = function remap (obj, transform, scope) {
   let map = {}
 
   for (var key in obj) {

--- a/src/signal.js
+++ b/src/signal.js
@@ -4,12 +4,11 @@
  */
 
 let chain       = require('./chain')
-let isGenerator = require('is-generator').fn
+let isGenerator = require('is-generator')
 let nodeify     = require('./nodeify')
 
-module.exports = function signal (action, params, callback) {
-  let value     = action.apply(null, params)
-  let processor = isGenerator(action) ? chain : nodeify
+module.exports = function signal (value, callback) {
+  let processor = isGenerator(value) ? chain : nodeify
 
   return processor(value, callback)
 }

--- a/src/tag.js
+++ b/src/tag.js
@@ -5,7 +5,7 @@
 
 let uid = 0
 
-module.exports = function(fn) {
+module.exports = function tag (fn) {
   let name = fn.name || 'microcosm_action'
   let mark = uid++
 


### PR DESCRIPTION
I'm starting to write the Microcosm dev tools and I noticed a couple of issues with our approach. Specifically, when I send transactions over `window.postMessage` to the Chrome extension, it includes a reference to the action type as a function. This is a problem when the browser attempts to serialize the object using this algorithm:

https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/The_structured_clone_algorithm

I still do not have an answer yet for `Error` objects returned by promises. They also don't serialize (which is really unfortunate). Still, this lays the groundwork.