### PR TITLE
Add ability to set payload on Transaction Create. FSA test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
   "babel": {
     "stage": 1,
     "sourceMaps": "inline",
-    "blacklist": [ "strict" ],
-    "plugins": [ "object-assign" ]
+    "blacklist": [
+      "strict"
+    ],
+    "plugins": [
+      "object-assign"
+    ]
   },
   "dependencies": {
     "diode": "~5.0",
@@ -43,6 +47,7 @@
     "classnames": "~2",
     "css-loader": "~0.15",
     "elizabot": "0.0.2",
+    "flux-standard-action": "^0.6.0",
     "istanbul": "~0.3",
     "istanbul-instrumenter-loader": "~0.1",
     "karma": "~>0.13.4",

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -6,10 +6,10 @@
 
 let async = require('./async')
 
-function create (type) {
+function create (type, payload=null) {
   return {
     type,
-    payload: null,
+    payload,
     meta: {
       active: false,
       done: false

--- a/src/__tests__/transaction-test.js
+++ b/src/__tests__/transaction-test.js
@@ -1,0 +1,12 @@
+let Transaction = require('../Transaction')
+let { isFSA } = require('flux-standard-action')
+
+describe('Transactions', function() {
+  it ('uses the flux standard action spec', function() {
+    isFSA(Transaction.create('test')).should.equal(true)
+  })
+
+  it ('can set a payload when created', function() {
+    Transaction.create('test', 'body').payload.should.equal('body')
+  })
+})


### PR DESCRIPTION
Not too much to report here. I wanted the ability to set a payload when creating a transaction and I added the [flux-standard-action](https://github.com/acdlite/flux-standard-action) standard test into the suite.