### PR TITLE
Stores can have a diversity of registration methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.3.0
+
+### Noticeable changes
+
+- Store registration methods can return non-function values. When this
+  is the case, it will use this value as the new state.
+
 ## 9.2.0
 
 ### Noticeable changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcosm",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "private": true,
   "description": "A variant of Facebook's Flux with centralized, isolated state",
   "main": "src/Microcosm.js",

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,7 +27,7 @@ exports.deserialize = function (store, raw) {
 }
 
 exports.send = function (store, state, { payload, type }) {
-  let pool = store.register? store.register() : null
+  let pool = typeof store.register === 'function' ? store.register() : null
 
   if (!pool || type in pool === false) {
     return state

--- a/src/Store.js
+++ b/src/Store.js
@@ -35,7 +35,7 @@ exports.send = function (store, state, { payload, type }) {
     pool = store.register()
   }
 
-  if (pool == undefined || type in pool === false) {
+  if (pool == null || type in pool === false) {
     return state
   }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,7 +27,19 @@ exports.deserialize = function (store, raw) {
 }
 
 exports.send = function (store, state, { payload, type }) {
-  let handler = store.register? store.register()[type] : false
+  let pool = null
 
-  return handler ? handler.call(store, state, payload) : state
+  if (typeof store === 'function') {
+    pool = store()
+  } else if (typeof store.register === 'function') {
+    pool = store.register()
+  }
+
+  if (pool == undefined || type in pool === false) {
+    return state
+  }
+
+  let handler = pool[type]
+
+  return typeof handler === 'function' ? handler.call(store, state, payload) : handler
 }

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,15 +27,9 @@ exports.deserialize = function (store, raw) {
 }
 
 exports.send = function (store, state, { payload, type }) {
-  let pool = null
+  let pool = store.register? store.register() : null
 
-  if (typeof store === 'function') {
-    pool = store()
-  } else if (typeof store.register === 'function') {
-    pool = store.register()
-  }
-
-  if (pool == null || type in pool === false) {
+  if (!pool || type in pool === false) {
     return state
   }
 

--- a/src/__tests__/stores-test.js
+++ b/src/__tests__/stores-test.js
@@ -60,6 +60,35 @@ describe('Stores', function() {
       let answer = Store.send({}, 'state', Transaction.create('fiz'))
       assert.equal(answer, 'state')
     })
+
+    it ('handles cases when a store is a function', function() {
+      let store = function() {
+        return {
+          action: (a, b) => a * b
+        }
+      }
+
+      let answer = Store.send(store, 2, Transaction.create('action', 2))
+      assert.equal(answer, 4)
+    })
+
+    it ('allows handlers to not be functions', function() {
+      let store = function() {
+        return {
+          action: 5
+        }
+      }
+
+      let answer = Store.send(store, 2, Transaction.create('action'))
+      assert.equal(answer, 5)
+    })
+
+    it ('does not modify state in cases where no registration value is returned', function() {
+      let store = function() {}
+
+      let answer = Store.send(store, 10, Transaction.create('action'))
+      assert.equal(answer, 10)
+    })
   })
 
 })

--- a/src/__tests__/stores-test.js
+++ b/src/__tests__/stores-test.js
@@ -61,21 +61,12 @@ describe('Stores', function() {
       assert.equal(answer, 'state')
     })
 
-    it ('handles cases when a store is a function', function() {
-      let store = function() {
-        return {
-          action: (a, b) => a * b
-        }
-      }
-
-      let answer = Store.send(store, 2, Transaction.create('action', 2))
-      assert.equal(answer, 4)
-    })
-
     it ('allows handlers to not be functions', function() {
-      let store = function() {
-        return {
-          action: 5
+      let store = {
+        register() {
+          return {
+            action: 5
+          }
         }
       }
 


### PR DESCRIPTION
This commit allows the following behaviors:

```javascript
function Store() {
  return {
    [action]: (a,b) => a + b
  }
}
```

```javascript
function Store() {
  return {
    [action]: 10
  }
}
```

This is to support some future work on refactoring the store, dispatching process. It also opens up the flexibility for stores to interact with other parts.