### PR TITLE
Make dispatch a pure function

### DIFF
--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -5,7 +5,7 @@ let eventually = require('./eventually')
 let flatten = require('./flatten')
 let install = require('./install')
 let lifecycle = require('./lifecycle')
-let send = require('./send')
+let dispatch = require('./dispatch')
 let tag = require('./tag')
 
 let Microcosm = function() {
@@ -87,28 +87,8 @@ Microcosm.prototype = {
     return this
   },
 
-  /**
-   * Dispatch takes an existing state and performs the result of a transaction
-   * on top of it. This is different than other Flux implementations, there
-   * are no side-effects.
-   *
-   * Dispatch answers the question:
-   * "What will change when I account for a transaction?"
-   */
   dispatch(state, transaction) {
-    let next = Object.assign({}, state)
-
-    for (var i = 0; i < this.stores.length; i++) {
-      var key   = this.stores[i][0]
-      var store = this.stores[i][1]
-      var answer = send(store, key, next, transaction)
-
-      if (answer !== void 0) {
-        next[key] = answer
-      }
-    }
-
-    return next
+    return dispatch(this.stores, state, transaction)
   },
 
   /**

--- a/src/__tests__/tag-test.js
+++ b/src/__tests__/tag-test.js
@@ -8,7 +8,7 @@ describe('tag', function() {
   })
 
   it ('assigns a default name', function() {
-    assert.equal(tag({}).toString().search('microcosm_action'), 0)
+    assert.equal(tag(function(){}).toString().search('microcosm_action'), 0)
   })
 
 })

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -13,9 +13,9 @@ module.exports = function dispatch(stores, state, transaction) {
   let next = Object.assign({}, state)
 
   for (var i = 0; i < stores.length; i++) {
-    var key   = stores[i][0]
-    var store = stores[i][1]
-    var answer = send(store, key, next, transaction)
+    let key   = stores[i][0]
+    let store = stores[i][1]
+    let answer = send(store, key, next, transaction)
 
     if (answer !== void 0) {
       next[key] = answer

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -1,0 +1,26 @@
+/**
+ * Dispatch takes an existing state and performs the result of a transaction
+ * on top of it. This is different than other Flux implementations, there
+ * are no side-effects.
+ *
+ * Dispatch answers the question:
+ * "What will change when I account for a transaction?"
+ */
+
+let send = require('./send')
+
+module.exports = function dispatch(stores, state, transaction) {
+  let next = Object.assign({}, state)
+
+  for (var i = 0; i < stores.length; i++) {
+    var key   = stores[i][0]
+    var store = stores[i][1]
+    var answer = send(store, key, next, transaction)
+
+    if (answer !== void 0) {
+      next[key] = answer
+    }
+  }
+
+  return next
+}

--- a/src/install.js
+++ b/src/install.js
@@ -7,6 +7,8 @@
  * of a Microcosm.
  */
 
+const NOOP = function(){}
+
 function checkPlugin (plugin) {
   if (process.env.NODE_ENV !== 'production' && ('register' in plugin) && typeof plugin.register !== 'function') {
     throw TypeError('Expected register property of plugin to be a function, instead got ' + plugin.register)
@@ -27,6 +29,6 @@ function installPlugin (next, plugin) {
   }
 }
 
-module.exports = function installPlugins (plugins, callback) {
+module.exports = function installPlugins (plugins, callback=NOOP) {
   return plugins.reduceRight(installPlugin, callback)(null)
 }

--- a/src/install.js
+++ b/src/install.js
@@ -7,8 +7,6 @@
  * of a Microcosm.
  */
 
-const NOOP = function(){}
-
 function checkPlugin (plugin) {
   if (process.env.NODE_ENV !== 'production' && ('register' in plugin) && typeof plugin.register !== 'function') {
     throw TypeError('Expected register property of plugin to be a function, instead got ' + plugin.register)
@@ -29,6 +27,6 @@ function installPlugin (next, plugin) {
   }
 }
 
-module.exports = function installPlugins (plugins, callback=NOOP) {
+module.exports = function installPlugins (plugins, callback) {
   return plugins.reduceRight(installPlugin, callback)(null)
 }

--- a/src/tag.js
+++ b/src/tag.js
@@ -6,6 +6,10 @@
 let uid = 0
 
 module.exports = function tag (fn) {
+  if (process.env.NODE_ENV !== 'production' && (typeof fn !== 'function')) {
+    throw TypeError('Attempted to tag an action, but the provided value is not a function. Instead got ' + typeof fn)
+  }
+
   let name = fn.name || 'microcosm_action'
   let mark = uid++
 


### PR DESCRIPTION
I'm working on some future work that requires the `dispatch` method to be pure. This commit extracts the dispatch function into a separate module. 