### PR TITLE
Respect bound callbacks. Add greater test coverage

### DIFF
--- a/src/__tests__/eventually-test.js
+++ b/src/__tests__/eventually-test.js
@@ -1,12 +1,39 @@
+import Promise from 'promise'
 import assert from 'assert'
 import eventually from '../eventually'
 
 describe('eventually', function() {
 
+
   it ('returns undefined if not given a function', function() {
     assert.equal(eventually(), undefined)
     assert.equal(eventually(undefined), undefined)
     assert.equal(eventually(3), undefined)
+  })
+
+  it ('respects the scope of bound functions', function(done) {
+    eventually(function() {
+      assert.equal(this, 'test')
+      done()
+    }.bind('test'))
+  })
+
+  it ('does not allow promises callbacks to absorb errors', function(done) {
+    let originalTimeout = global.setTimeout
+
+    global.setTimeout = function(callback) {
+      assert.throws(callback, /It worked/)
+      global.setTimeout = originalTimeout
+      done()
+    }
+
+    Promise.resolve().then(function() {
+      eventually(function() {
+        throw new Error('It worked')
+      })
+    }).catch(function(error) {
+      done(new Error('The promise caught the error in `eventually`.'))
+    })
   })
 
 })

--- a/src/eventually.js
+++ b/src/eventually.js
@@ -9,6 +9,10 @@ module.exports = function eventually (fn, scope, error, payload) {
    *
    * Note: Referencing setTimeout from global allows for higher
    * v8 optimization.
+   *
+   * Note: `fn.call` is intentionally used over `fn.bind`.
+   * This is to respect functions where `bind` has already been
+   * invoked (like `ReactComponent::setState`).
    */
-  return global.setTimeout(fn.bind(scope, error, payload))
+  return global.setTimeout(() => fn.call(scope, error, payload))
 }


### PR DESCRIPTION
I want to support the following behavior:

```
app.push(action, params, reactComponent.method)
```

Up until now I was binding all `push` callbacks to `app`. That is problematic for this use case. Instead, I now use `call` inside of an anonymous function to respect `Function::bind`.

While I was at it, I also added test coverage to make sure that errors throw inside of `eventually` are not absorbed by promises. What a mind bender...