### PR TITLE
Allow generators to use generators

### DIFF
--- a/src/__tests__/dispatch-generator-test.js
+++ b/src/__tests__/dispatch-generator-test.js
@@ -99,4 +99,35 @@ describe('When dispatching generators', function() {
 
     app.push(single, 4)
   })
+
+  it ('runs results through coroutine', function(done) {
+    let app = new Microcosm()
+
+    function* range(start, end) {
+      while (start < end) {
+        yield start++
+      }
+    }
+
+    function* generatorOfGenerators(a, b) {
+      yield range(a, b)
+    }
+
+    app.addStore('test', {
+      register() {
+        return {
+          // Test concatenation to ensure the state is the same every
+          // single time
+          [generatorOfGenerators]: (a=[], b) => a.concat(b)
+        }
+      }
+    })
+
+    app.start()
+
+    app.push(generatorOfGenerators, [1, 4], function() {
+      assert.deepEqual(app.state.test, [3])
+      done()
+    })
+  })
 })

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -36,9 +36,11 @@ let waterfall = function (iterator, callback) {
   return coroutine(iterator.next().value, function step (error, body) {
     let { done, value } = iterator.next()
 
-    callback(error, body, done)
+    if (error) {
+      return callback(error, body, true)
+    }
 
-    return done ? body : coroutine(value, step)
+    return done ? coroutine(body, callback) : coroutine(value, step)
   })
 }
 


### PR DESCRIPTION
This PR allows generators actions to compose other generator actions. Really, it fixes a bug where yielding generators returns the generator itself to the store. Keeping with the expectation, i want to continue to break down the complex data types until I get a primitive value.