### PR TITLE
Pass body into yield block.

### DIFF
--- a/src/__tests__/coroutine-test.js
+++ b/src/__tests__/coroutine-test.js
@@ -1,0 +1,25 @@
+import coroutine from '../coroutine'
+import assert from 'assert'
+import Promise from 'promise'
+
+describe('coroutines', function() {
+
+  it ('returns the results back to yields in generators', function(done) {
+    function* test () {
+      var first = yield Promise.resolve('test')
+      assert.equal(first, 'test')
+
+      var second = yield Promise.resolve(first.toUpperCase())
+      assert.equal(second, 'TEST')
+    }
+
+    coroutine(test(), function(error, body, complete) {
+      if (complete) {
+        assert.equal(body, 'TEST')
+        assert(complete)
+        done(error)
+      }
+    })
+  })
+
+})

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -44,7 +44,7 @@ let waterfall = function (iterator, callback) {
       return callback(error, body, false)
     }
 
-    let next = iterator.next()
+    let next = iterator.next(body)
 
     callback(error, body, next.done)
 


### PR DESCRIPTION
Allows for two way communication in generator actions:

```javascript
function* test () {
  var first = yield Promise.resolve('test')
  assert.equal(first, 'test')

  var second = yield Promise.resolve(first.toUpperCase())
  assert.equal(second, 'TEST')
}
```

So basically, you can lean on Microcosm to reduce the promise into a real value and perform future operations as if they were synchronous. Pretty cool.