### PR TITLE
Key paths

### DIFF
--- a/src/__tests__/Microcosm-test.js
+++ b/src/__tests__/Microcosm-test.js
@@ -21,7 +21,8 @@ describe('Microcosm', function() {
       }
     }
 
-    assert.ok(new Map(new MyApp().stores).has('foo'))
+    assert.ok(new MyApp() instanceof MyApp)
+    assert.equal(new MyApp().stores.length, 1)
   })
 
   describe('reset', function() {

--- a/src/__tests__/store-test.js
+++ b/src/__tests__/store-test.js
@@ -3,24 +3,6 @@ let assert    = require('assert')
 
 describe('Stores', function() {
 
-  it ('throws an error if a non-string key is given in addStore', function(done) {
-    try {
-      new Microcosm().addStore({})
-    } catch(x) {
-      assert(x instanceof TypeError)
-      done()
-    }
-  })
-
-  it ('throws an error if missing a store', function(done) {
-    try {
-      new Microcosm().addStore('foo')
-    } catch(x) {
-      assert(x instanceof TypeError)
-      done()
-    }
-  })
-
   it ('a store can be a function', function(done) {
     let action = function() {}
     let app = new Microcosm()

--- a/src/__tests__/store-test.js
+++ b/src/__tests__/store-test.js
@@ -19,4 +19,27 @@ describe('Stores', function() {
     })
   })
 
+  it ('can mount a store at a nested key path', function() {
+    let app = new Microcosm()
+
+    app.addStore([ 'foo', 'bar' ], {
+      getInitialState() {
+        return true
+      }
+    })
+
+    assert(app.state.foo.bar)
+  })
+
+  it ('can mount a store at an empty key path', function() {
+    let app = new Microcosm()
+
+    app.addStore({
+      getInitialState() {
+        return { test: true }
+      }
+    })
+
+    assert(app.state.test)
+  })
 })

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -7,15 +7,16 @@
  */
 
 import send from './send'
+import { get, set } from './update'
 
 let dispatch = function (stores, state, { active, payload, type }) {
   for (var i = 0, len = stores.length; active && i < len; i++) {
     var [ key, store ] = stores[i]
 
-    var answer = send(store, type, state[key], payload, state)
+    var answer = send(store, type, get(state, key), payload, state)
 
-    if (answer !== void 0) {
-      state[key] = answer
+    if (answer !== undefined) {
+      state = set(state, key, answer)
     }
   }
 

--- a/src/update.js
+++ b/src/update.js
@@ -1,0 +1,22 @@
+import merge from './merge'
+
+export function get (target, keys) {
+  for (var i = 0; target && i < keys.length; i++) {
+    target = target[keys[i]]
+  }
+
+  return target
+}
+
+export function set (target, keys, value) {
+  if (keys.length) {
+    let head  = keys[0]
+    let clone = merge({}, target)
+
+    clone[head] = keys.length > 1 ? set(clone[head] || {}, keys.slice(1), value) : value
+
+    return clone
+  } else {
+    return value
+  }
+}

--- a/src/update.js
+++ b/src/update.js
@@ -1,7 +1,7 @@
 import merge from './merge'
 
 export function get (target, keys) {
-  for (var i = 0; target && i < keys.length; i++) {
+  for (var i = 0; target !== undefined && i < keys.length; i++) {
     target = target[keys[i]]
   }
 


### PR DESCRIPTION
When upgrading Colonel Kurtz to the latest version of Microcosm, I bumped into some friction moving away from our old API that allowed:

```
app.set('abitrary-key', stuff)
```

This allowed a user to directly modify application state, which was extremely problematic when we moved to storing changes as a series of transactions over time. I'm really glad we moved away from this, however it did expose an issue: 

All stores must be mounted to a namespaced key, so there's no efficient way to directly assign a single-value key to the root state object. This makes it cumbersome to perform operations on the entire state object itself.

This PR adds support for this by implementing key path access to app state. This means that a store can be mounted to an array of keys and Microcosm will drill into the global app state object to assign a new value. 

All modifications occur immutably, which means we take about a 3-4ms penalty on our dispatch benchmark. That isn't great, but I think I can make up the efficiencies somewhere else in the pipeline. Regardless of the performance regression (which is over 10,000 transactions, more than 200 times what I've ever seen in the wild), I've bumped into this several times working on projects with Microcosm, and I think it's an important addition.

```javascript
import { willStart } from 'microcosm/lifecycle'

app.addStore(function() {
    return {
        [willStart]: { test: true }
    }
})

assert(app.state.test)
```

```javascript
app.addStore([ 'foo', 'bar', 'baz' ], {
    getInitialState() {
        return true
    }
})
assert(app.state.foo.bar.baz)
```