### PR TITLE
Nh revisit start and tree

### DIFF
--- a/benchmarks/dispatch-performance.js
+++ b/benchmarks/dispatch-performance.js
@@ -52,6 +52,8 @@ app.addStore('three', Store)
 app.addStore('four',  Store)
 app.addStore('five',  Store)
 
+app.start()
+
 /**
  * Append a given number of transactions into history. We use this method
  * instead of `::push()` for benchmark setup performance. At the time of writing,

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -37,7 +37,7 @@ let Microcosm = function() {
 
   this.stores  = []
   this.plugins = []
-  this.history = new Tree(Transaction(lifecycle.willStart, true, true))
+  this.history = new Tree()
 
   this.addStore(MetaStore)
 }
@@ -173,15 +173,12 @@ Microcosm.prototype = {
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      if (typeof store !== 'function' && typeof store !== 'object') {
-        throw TypeError('Expected a store object or function. Instead got: ' + typeof store)
+      if (!store || typeof store !== 'function' && typeof store !== 'object') {
+        throw TypeError('Expected a store object or function. Instead got: ' + store)
       }
     }
 
     this.stores.push([ flatten(keyPath), defaults(store) ])
-
-    // Re-evaluate the current state including the new store
-    this.rollforward()
 
     return this
   },
@@ -218,8 +215,10 @@ Microcosm.prototype = {
    *    genrateed if installing plugins fails.
    */
   start(callback) {
-    this.reset()
+    this.push(lifecycle.willStart)
+
     install(this.plugins, callback)
+
     return this
   }
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -4,12 +4,8 @@
  * over time.
  */
 
-function Tree (anchor) {
+function Tree () {
   this.focus = null
-
-  if (anchor) {
-    this.append(anchor)
-  }
 }
 
 Tree.prototype = {
@@ -23,11 +19,15 @@ Tree.prototype = {
   },
 
   back() {
-    this.checkout(this.focus.parent)
+    if (this.focus) {
+      this.checkout(this.focus.parent)
+    }
   },
 
   forward() {
-    this.checkout(this.focus.next())
+    if (this.focus) {
+      this.checkout(this.focus.next())
+    }
   },
 
   append(item) {
@@ -36,19 +36,19 @@ Tree.prototype = {
     return this.focus
   },
 
-  prune(fn) {
+  prune(shouldRemove) {
     let node = this.root()
 
-    while (node && fn(node.value)) {
+    while (node && shouldRemove(node.value)) {
       node.dispose()
-
-      // If we dispose the focal point, release it
-      // from the tree
-      if (node === this.focus) {
-        this.focus = null
-      }
-
       node = node.next()
+    }
+
+    // If we reach the end (there is no next node), it means
+    // we've completely wiped away the tree, so nullify focus
+    // to mark a completely empty tree.
+    if (!node) {
+      this.focus = null
     }
   },
 
@@ -56,7 +56,7 @@ Tree.prototype = {
     let node  = this.focus
     let items = []
 
-    while (node !== null) {
+    while (node) {
       items.push(node.value)
       node = node.parent
     }
@@ -67,7 +67,7 @@ Tree.prototype = {
   root() {
     let node = this.focus
 
-    while (node !== null && node.parent !== null) {
+    while (node && node.parent) {
       node = node.parent
     }
 
@@ -78,8 +78,8 @@ Tree.prototype = {
     let count = 0
     let next  = this.focus
 
-    while (next !== null) {
-      next = next.parent
+    while (next) {
+      next  = next.parent
       count = count + 1
     }
 
@@ -90,18 +90,18 @@ Tree.prototype = {
 
 function Node (value, parent) {
   this.children = []
-  this.parent   = parent || null
+  this.parent   = parent
   this.value    = value
 
   if (parent) {
-    parent.children.unshift(this)
+    parent.children.push(this)
   }
 }
 
 Node.prototype = {
 
   next() {
-    return this.children[0] || null
+    return this.children.length ? this.children[0] : null
   },
 
   dispose() {

--- a/test/Tree-test.js
+++ b/test/Tree-test.js
@@ -41,8 +41,9 @@ describe('Tree', function() {
   })
 
   it ('step back through the tree', function() {
-    let tree = new Tree('first')
+    let tree = new Tree()
 
+    tree.append('first')
     tree.append('second')
     tree.append('third')
 
@@ -82,8 +83,9 @@ describe('Tree', function() {
   })
 
   it ('properly handles forks', function() {
-    let tree = new Tree('one')
+    let tree = new Tree()
 
+    let one   = tree.append('one')
     let two   = tree.append('two')
     let three = tree.append('three')
 
@@ -121,6 +123,14 @@ describe('Tree', function() {
     assert.equal(tree.focus, one)
   })
 
+  it ('will not move back if there is no focus', function() {
+    let tree = new Tree()
+
+    tree.back()
+
+    assert.equal(tree.focus, null)
+  })
+
   it ('will not move backwards out of the tree', function() {
     let tree = new Tree()
 
@@ -143,6 +153,14 @@ describe('Tree', function() {
 
     tree.forward()
     assert.equal(tree.focus, two)
+  })
+
+  it ('will not move forward if there is no focus', function() {
+    let tree = new Tree()
+
+    tree.forward()
+
+    assert.equal(tree.focus, null)
   })
 
   it ('will not move forward out of the tree', function() {

--- a/test/dispatch-primitive-test.js
+++ b/test/dispatch-primitive-test.js
@@ -16,7 +16,10 @@ describe('When dispatching primitive values', function() {
 
   it ('properly reduces from a store', function(done) {
     app = new Microcosm()
+
     app.addStore('test', Store)
+
+    app.start()
 
     app.push(add, 2, function() {
       assert.equal(app.state.test, 3)

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -20,12 +20,13 @@ describe('Stores', function() {
   })
 
   it ('throws if not given a store', function() {
-    let app = new Microcosm()
+    let app   = new Microcosm()
+    let error = new RegExp('Expected a store object or function')
 
-    assert.throws(() => app.addStore('test'))
-    assert.throws(() => app.addStore('test', 'fiz'))
-    assert.throws(() => app.addStore('test', null))
-    assert.throws(() => app.addStore(null))
+    assert.throws(() => app.addStore('test'), error)
+    assert.throws(() => app.addStore('test', 'fiz'), error)
+    assert.throws(() => app.addStore('test', null), error)
+    assert.throws(() => app.addStore(null), error)
   })
 
   it ('can mount a store at a nested key path', function() {
@@ -36,6 +37,8 @@ describe('Stores', function() {
         return true
       }
     })
+
+    app.start()
 
     assert(app.state.foo.bar)
   })
@@ -48,6 +51,8 @@ describe('Stores', function() {
         return { test: true }
       }
     })
+
+    app.start()
 
     assert(app.state.test)
   })


### PR DESCRIPTION
@solomonhawk and @mzlock found some fun issues in transaction history that would cause store handlers to execute more times than expected. We've addressed that in the latest beta release (9.14.1-beta), however I wanted to rethink this a bit.

There are a couple of changes:

- Do not re-evaluate state when a store is added. In future releases, I may consider throwing an error if a store is added after a Microcosm starts.
- `:start()` pushes the `willStart` lifecycle action instead of resetting. This sounds pretty obvious, I'm not sure why it wasn't this way before.
- Removed some `null` optimization checks that aren't necessary.