### PR TITLE
Tree should push children to beginning of list. Small Tree.js refactoring.

### DIFF
--- a/examples/undo-tree/app/components/drawing.jsx
+++ b/examples/undo-tree/app/components/drawing.jsx
@@ -16,6 +16,7 @@ const Drawing = React.createClass({
 
         <footer>
           <button onClick={ () => app.undo() }>Undo</button>
+          <button onClick={ () => app.redo() }>Redo</button>
         </footer>
       </main>
     )

--- a/examples/undo-tree/app/undo-tree.js
+++ b/examples/undo-tree/app/undo-tree.js
@@ -17,6 +17,11 @@ export default class UndoTree extends Microcosm {
     this.rollforward()
   }
 
+  redo() {
+    this.history.forward()
+    this.rollforward()
+  }
+
   goto(node) {
     this.history.checkout(node)
     this.rollforward()

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -87,7 +87,7 @@ Microcosm.prototype = {
   },
 
   transactionWillClose() {
-    this.history.prune(transaction => this.clean(transaction))
+    this.history.prune(this.clean, this)
   },
 
   /**

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -4,18 +4,18 @@
  * over time.
  */
 
-function Tree () {
-  this.focus = null
-}
+function Tree () {}
 
 Tree.prototype = {
+
+  focus: null,
 
   checkout(node) {
     if (process.env.NODE_ENV !== 'production' && typeof node === 'undefined') {
       throw new TypeError('Tree was asked to focus on a Node, but instead got ' + node)
     }
 
-    this.focus = node != null ? node : this.focus
+    this.focus = node || this.focus
   },
 
   back() {
@@ -32,14 +32,13 @@ Tree.prototype = {
 
   append(item) {
     this.focus = new Node(item, this.focus)
-
     return this.focus
   },
 
-  prune(shouldRemove) {
+  prune(shouldRemove, scope) {
     let node = this.root()
 
-    while (node && shouldRemove(node.value)) {
+    while (node && shouldRemove.call(scope, node.value)) {
       node.dispose()
       node = node.next()
     }
@@ -76,10 +75,10 @@ Tree.prototype = {
 
   size() {
     let count = 0
-    let next  = this.focus
+    let node  = this.focus
 
-    while (next) {
-      next  = next.parent
+    while (node) {
+      node  = node.parent
       count = count + 1
     }
 
@@ -94,7 +93,7 @@ function Node (value, parent) {
   this.value    = value
 
   if (parent) {
-    parent.children.push(this)
+    parent.children.unshift(this)
   }
 }
 


### PR DESCRIPTION
This commit changes the order in which child nodes of the Tree data structure are appended. This allows for "redo" functionality that moves forward to the most recent change.

![undo](https://cloud.githubusercontent.com/assets/590904/11473094/8c21fc20-973e-11e5-8c58-34496d916025.gif)