### PR TITLE
Add push benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,4 @@ test-watch:
 bench: javascript
 	@ node --expose-gc --trace-deopt benchmarks/tree-performance
 	@ node --expose-gc --trace-deopt benchmarks/dispatch-performance
+	@ node --expose-gc --trace-deopt benchmarks/push-performance

--- a/benchmarks/push-performance.js
+++ b/benchmarks/push-performance.js
@@ -16,7 +16,7 @@ action.toString = function () { return 'test' }
 var Store = function() {
   return {
     getInitialState: 0,
-    test: function(n) { return n + 1}
+    test: function(n) { return n + 1 }
   }
 }
 

--- a/benchmarks/push-performance.js
+++ b/benchmarks/push-performance.js
@@ -1,27 +1,14 @@
 /**
- * Dispatch Performance Benchmark
- * The goal of this script is to evaluate if our goal of 10,000
- * uniquely folded transactions can be done in under 16ms.
- *
- * This test does not account for hardware diversity. It is a simple
- * gut check of "are we fast yet?"
+ * Push Performance Benchmark
+ * Measures the performance of pushing a single action.
  */
 
 var Microcosm   = require('../dist/Microcosm')
 var Transaction = require('../dist/Transaction')
-var time  = require('microtime')
-var SIZE = 10000
+var time        = require('microtime')
+var SIZE        = 10000
 
 var app = new Microcosm()
-
-/**
- * Disable the default merger strategy. This prevents
- * transactions from cleaning up, which will cause more
- * than one complete transaction to merge at a time.
- */
-app.shouldHistoryKeep = function () {
-  return true
-}
 
 var action = function test () {}
 action.toString = function () { return 'test' }
@@ -46,27 +33,20 @@ app.addStore('five',  Store)
 
 app.start()
 
+var then = time.now()
+
 /**
  * Append a given number of transactions into history. We use this method
  * instead of `::push()` for benchmark setup performance. At the time of writing,
  * `push` takes anywhere from 0.5ms to 15ms depending on the sample range.
  * This adds up to a very slow boot time!
  */
+
 for (var i = 0; i < SIZE; i++) {
-  app.history.append(Transaction(action, true, true))
+  app.push(action)
 }
 
-/**
- * Warm up `::push()`
- * This gives V8 time to analyze the types for the code.
- * Otherwise confusing "insufficient type data" deoptimizations
- * are thrown.
- */
+var total   = (time.now() - then) / 1000
+var average = total / SIZE
 
-for (var q = 0; q < 10; q++) {
-  app.push(action, true)
-}
-
-var then = time.now()
-app.push(action, true)
-console.log('Dispatched %s actions in %sms\n', SIZE, (time.now() - then) / 1000)
+console.log('Pushed %s actions in %sms (average of %sms)\n', SIZE, total, average)


### PR DESCRIPTION
This PR adds another benchmark for general push performance. It's near instant, but I wanted to set up a benchmark before exploring some potential updates to this function.

![screen shot 2015-11-30 at 9 16 09 am](https://cloud.githubusercontent.com/assets/590904/11473863/01eca8f2-9743-11e5-839b-b4a852c9e8d7.png)
