### PR TITLE
Plugins can be synchronous

### DIFF
--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -28,16 +28,17 @@ Plugins implement a `register` method that is called whenever an application is
 started:
 
 ```javascript
-let LazyPlugin = {
-  register(app, options, next) {
-    setTimeout(next, 2000);
+let Plugin = {
+  register(app, options) {
+    app.listen(function(data) {
+      console.log('I changed!', data)
+    })
   }
 }
 ```
 
-This plugin will delay execution of the app for 2 seconds. This
-expresses the nature of plugins. They can be asynchronous, to support
-non-immediate (but vital) tasks:
+However Plugins can also be asynchronous. This is useful for plugins
+that might fail, or for non-immediate (but vital) tasks.
 
 For example: What if you want to fetch data before an application begins?
 
@@ -50,7 +51,7 @@ let Prefetcher = {
 
     route.fetchData()
          .then(app.seed)
-         .then(i => next)
+         .then(i => next())
   }
 }
 ```
@@ -69,7 +70,7 @@ let Prefetcher = {
 
     route.fetchData()
          .then(app.seed)
-         .then(i => next)
+         .then(i => next())
          .catch(error => next(error))
   }
 }

--- a/examples/simple-svg/app/plugins/render.js
+++ b/examples/simple-svg/app/plugins/render.js
@@ -3,7 +3,7 @@ import DOM   from 'react-dom'
 import React from 'react'
 import { update } from '../actions/circle'
 
-export default function Render (app, el, next) {
+export default function Render (app, el) {
   function render (state) {
     DOM.render(<Viget { ...state } />, el)
   }
@@ -16,6 +16,4 @@ export default function Render (app, el, next) {
     requestAnimationFrame(loop)
     app.push(update)
   })
-
-  next()
 }

--- a/src/install.js
+++ b/src/install.js
@@ -9,9 +9,26 @@
 
 const NOOP = () => {}
 
+function ensureCallback (plugin) {
+  // Plugins that follow register(app, options, next) are asynchronous
+  if (plugin.register.length >= 3) {
+    return plugin.register
+  }
+
+  // Otherwise wrap synchronous plugins to match the async flow
+  return function (app, options, next) {
+    plugin.register(app, options)
+    next(null)
+  }
+}
+
 function installPlugin (next, plugin) {
   return function (error) {
-    return error != null ? next(error) : plugin.register(plugin.app, plugin.options, next)
+    if (error != null) {
+      return next(error)
+    }
+
+    return ensureCallback(plugin).call(plugin, plugin.app, plugin.options, next)
   }
 }
 

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -112,4 +112,14 @@ describe('Plugins', function() {
 
     app.start()
   })
+
+  it ('just calls through plugins that have no next callback', function(done) {
+    let app = new Microcosm()
+
+    app.addPlugin(function(app, _) {
+      // intentionally nothing
+    })
+
+    app.start(done)
+  })
 })

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -117,9 +117,12 @@ describe('Plugins', function() {
     let app = new Microcosm()
 
     app.addPlugin(function(app, _) {
-      // intentionally nothing
+      app.didAddPlugin = true
     })
 
-    app.start(done)
+    app.start(function(errors) {
+      assert.equal(app.didAddPlugin, true)
+      done(errors)
+    })
   })
 })


### PR DESCRIPTION
If a plugin does not provide a `next` argument, it would be considered synchronous. This is to prevent the tedium of calling `next()` for otherwise synchronous tasks:

```javascript
const Logger  = {

  register(app, options) {

    app.listen(function() {
      console.log("I changed!")
    })
}
```