### PR TITLE
Move bad action pushing to app. Improve message

### DIFF
--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -96,6 +96,13 @@ Microcosm.prototype = {
    * and the change will disappear from history.
    */
   push(action, params, callback) {
+    if (process.env.NODE_ENV !== 'production' && action == null) {
+      throw new TypeError(`Unable to perform: app.push(${ action })\n\n`
+                          + 'This typically happens when an action is accessed from the wrong key of an object, such as:\n\n'
+                          + '• Actions.mispelledAction\n'
+                          + '• import { mispelledAction } from "actions"')
+    }
+
     let transaction = Transaction(tag(action))
     let body = action.apply(null, flatten(params))
 

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -4,10 +4,6 @@
  */
 
 export default function Transaction (type, payload, complete) {
-  if (process.env.NODE_ENV !== 'production' && !type) {
-    throw new TypeError('Transaction was created with the invalid type: ' + type)
-  }
-
   return {
     type     : `${ type }`,
     error    : false,

--- a/test/Microcosm-test.js
+++ b/test/Microcosm-test.js
@@ -106,4 +106,10 @@ describe('Microcosm', function() {
     assert.deepEqual(app.history.branch().reduce((a, b) => a.concat(b.payload), []), [ 2, 3, 4, 5, 6 ])
   })
 
+  it ('throws an error if asked to push an undefined action', function() {
+    assert.throws(function() {
+      app.push(undefined)
+    })
+  })
+
 })

--- a/test/transaction-test.js
+++ b/test/transaction-test.js
@@ -16,10 +16,4 @@ describe('Transactions', function() {
     assert.equal(Transaction(2, 2).active, true)
   })
 
-  it ('throws if not given a type', function() {
-    assert.throws(function() {
-      Transaction()
-    })
-  })
-
 })


### PR DESCRIPTION
I hit this on a project and it got me thinking... Ideally the `Transaction` module shouldn't be presented to the developer. This is a private module. With that in mind, I moved the "bad action" error to `app.push`, and improved the messaging:

![screen shot 2016-01-14 at 9 06 28 am](https://cloud.githubusercontent.com/assets/590904/12326317/201a2d62-ba9e-11e5-9119-663997cc2b81.png)
