### PR TITLE
Start throws errors by default if not provided a callback

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -7,7 +7,11 @@
  * of a Microcosm.
  */
 
-const NOOP = () => {}
+function defaultCallback (error) {
+  if (error) {
+    throw error
+  }
+}
 
 function ensureCallback (plugin) {
   // Plugins that follow register(app, options, next) are asynchronous
@@ -35,6 +39,6 @@ function installPlugin (next, plugin) {
   }
 }
 
-export default function (plugins, callback=NOOP) {
+export default function (plugins, callback=defaultCallback) {
   return plugins.reduceRight(installPlugin, callback)()
 }

--- a/test/Microcosm-test.js
+++ b/test/Microcosm-test.js
@@ -106,16 +106,16 @@ describe('Microcosm', function() {
     })
   })
 
-  it ('throws errors by default if a callback is not provided to start', function() {
-    let app = new Microcosm()
+  context('when a microcosm plugin passes an error', function() {
+    let app   = new Microcosm()
     let error = 'This error should exist!'
 
-    app.addPlugin(function willPassError (app, options, next) {
+    app.addPlugin(function willFail (app, options, next) {
       next(error)
     })
 
-    assert.throws(function() {
-      app.start()
-    }, error)
+    it ('start() throws the error if a callback is not provided', function() {
+      assert.throws(app.start, error)
+    })
   })
 })

--- a/test/Microcosm-test.js
+++ b/test/Microcosm-test.js
@@ -106,4 +106,16 @@ describe('Microcosm', function() {
     })
   })
 
+  it ('throws errors by default if a callback is not provided to start', function() {
+    let app = new Microcosm()
+    let error = 'This error should exist!'
+
+    app.addPlugin(function willPassError (app, options, next) {
+      next(error)
+    })
+
+    assert.throws(function() {
+      app.start()
+    }, error)
+  })
 })


### PR DESCRIPTION
If `app.start()` is invoked and no callback is provided, errors passed through the plugin process will raise an exception. 

Basically, I'm tired of having to do this by hand on every single project:

```javascript
app.start(function(error) {
    if (error) {
        throw error
    }
})
```