### PR TITLE
Promise callbacks should receive action payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.19.1
+
+- Fixes a regression introduced in 9.6.0 where the promise payload was
+  not being returned from push, this prevented promise chains from
+  receiving the transaction payload.
+
 ## 9.19.0
 
 - Added Provider and Connect addons. See the API docs for more

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -117,6 +117,8 @@ Microcosm.prototype = {
       }
 
       this.rollforward()
+
+      return payload
     })
   },
 

--- a/test/dispatch-promise-test.js
+++ b/test/dispatch-promise-test.js
@@ -102,4 +102,16 @@ describe('When dispatching promises', function() {
       done()
     })
   })
+
+
+  it ('returns the original payload when dispatching a promise', function (done) {
+    function testAction (number) {
+      return Promise.resolve(number)
+    }
+
+    app.push(testAction, 2).done(function(params) {
+      assert.equal(params, 2)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This commit fixes a regression introduced in `9.6.0` where the promise payload was not being returned from `push`, this prevented promise chains from receiving the transaction payload.

Basically:

```javascript
function action (params) {
  return Promise.resolve(params)
}

app.push(action, 'foobar').done(function (payload) {
    assert.equal(payload, 'foobar')
})
```
Pretty safe bug fix. This does not effect action callbacks, like:

```javascript
app.push(action, params, function (error, payload) {
    // still correct behavior
})
```