### PR TITLE
Eliminate the need to set a timeout on every callback

### DIFF
--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -3,9 +3,8 @@
  * An account of what has happened.
  */
 
-import coroutine  from './coroutine'
-import flatten    from './flatten'
-import eventually from './eventually'
+import coroutine from './coroutine'
+import flatten   from './flatten'
 
 export default function Transaction (action, payload) {
   this.action  = action
@@ -32,8 +31,8 @@ Transaction.prototype = {
 
       onNext.call(scope, this)
 
-      if (done) {
-        eventually(onComplete, scope, error, payload)
+      if (done && onComplete) {
+        onComplete.call(scope, error, payload)
       }
 
       return payload

--- a/src/eventually.js
+++ b/src/eventually.js
@@ -1,10 +1,4 @@
-import { isFunction } from './type-checks'
-
 function eventually (fn, scope, error, payload) {
-  if (!isFunction(fn)) {
-    return undefined
-  }
-
   /**
    * This is a neat trick to get around the promise try/catch:
    * https://github.com/then/promise/blob/master/src/done.js

--- a/src/update.js
+++ b/src/update.js
@@ -9,6 +9,10 @@ export function get (target, keys) {
 }
 
 export function set (target, keys, value) {
+  if (get(target, keys) === value) {
+    return target
+  }
+
   if (keys.length) {
     let head  = keys[0]
     let clone = merge({}, target)

--- a/test/dispatch-generator-test.js
+++ b/test/dispatch-generator-test.js
@@ -76,7 +76,7 @@ describe('When dispatching generators', function() {
       yield n
       yield new Promise((resolve, reject) => setTimeout(function() {
         reject(new Error('Rejected Promise'))
-      }, 50))
+      }))
     }
 
     app.addStore('test', {

--- a/test/dispatch-promise-test.js
+++ b/test/dispatch-promise-test.js
@@ -12,12 +12,12 @@ describe('When dispatching promises', function() {
   let chain  = n => Promise.resolve(n).then(n => Promise.resolve(n))
   let error  = function(n) {
     return new Promise(function (resolve, reject) {
-      setTimeout(reject, 100)
+      setTimeout(reject)
     })
   }
   let late = function(n) {
     return new Promise(function (resolve, reject) {
-      setTimeout(_ => resolve(n), 50)
+      setTimeout(_ => resolve(n))
     })
   }
 

--- a/test/eventually-test.js
+++ b/test/eventually-test.js
@@ -12,13 +12,6 @@ describe('eventually', function() {
     global.setTimeout = this.originalTimeout
   })
 
-
-  it ('returns undefined if not given a function', function() {
-    assert.equal(eventually(), undefined)
-    assert.equal(eventually(undefined), undefined)
-    assert.equal(eventually(3), undefined)
-  })
-
   it ('respects the scope of bound functions', function(done) {
     eventually(function() {
       assert.equal(this, 'test')

--- a/test/mutation-test.js
+++ b/test/mutation-test.js
@@ -1,0 +1,36 @@
+let Microcosm = require('../src/Microcosm')
+let assert    = require('assert')
+
+describe('Mutation', function() {
+
+  context('when a store writes mutatively', function() {
+    let action = function() {}
+
+    beforeEach(function(done) {
+      this.app = new Microcosm()
+
+      this.app.addStore(function() {
+        return {
+          getInitialState() {
+            return { test: false }
+          },
+          [action](state) {
+            state.test = true
+            return state
+          }
+        }
+      })
+
+      this.app.start(done)
+    })
+
+
+    it ('it writes to application state', function (done) {
+      this.app.push(action, true, error => {
+        assert.equal(this.app.state.test, true)
+        done(error)
+      })
+    })
+  })
+
+})

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -38,4 +38,11 @@ describe('update.set', function() {
     assert.deepEqual(next.a.b, { c: true })
   })
 
+  it ('does not rewrite paths when the leaf values values are the same', function() {
+    let subject = { a: { b: { c: true } } }
+    let next = update.set(subject, [ 'a', 'b', 'c' ], true)
+
+    assert.deepEqual(subject, next)
+  })
+
 })


### PR DESCRIPTION
Since the addition of the [unpromise](https://github.com/vigetlabs/microcosm/blob/master/src/unpromise.js) function, Promise try/catch behavior no longer affects Microcosm internals. This means that we do not need to execute the callback of `app.push` within a set timeout.

This PR makes that change, and makes some updates to a few timeout-related tests that cut the test suite by a couple hundred milliseconds.

Technically, this also probably means that app.push callbacks execute quite a bit faster, but the real value here is that there's simply less machinery.