### PR TITLE
Do not clone objects when the target value is the same

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -9,6 +9,10 @@ export function get (target, keys) {
 }
 
 export function set (target, keys, value) {
+  if (get(target, keys) === value) {
+    return target
+  }
+
   if (keys.length) {
     let head  = keys[0]
     let clone = merge({}, target)

--- a/test/mutation-test.js
+++ b/test/mutation-test.js
@@ -1,0 +1,36 @@
+let Microcosm = require('../src/Microcosm')
+let assert    = require('assert')
+
+describe('Mutation', function() {
+
+  context('when a store writes mutatively', function() {
+    let action = function() {}
+
+    beforeEach(function(done) {
+      this.app = new Microcosm()
+
+      this.app.addStore(function() {
+        return {
+          getInitialState() {
+            return { test: false }
+          },
+          [action](state) {
+            state.test = true
+            return state
+          }
+        }
+      })
+
+      this.app.start(done)
+    })
+
+
+    it ('it writes to application state', function (done) {
+      this.app.push(action, true, error => {
+        assert.equal(this.app.state.test, true)
+        done(error)
+      })
+    })
+  })
+
+})

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -38,4 +38,11 @@ describe('update.set', function() {
     assert.deepEqual(next.a.b, { c: true })
   })
 
+  it ('does not rewrite paths when the leaf values values are the same', function() {
+    let subject = { a: { b: { c: true } } }
+    let next = update.set(subject, [ 'a', 'b', 'c' ], true)
+
+    assert.deepEqual(subject, next)
+  })
+
 })


### PR DESCRIPTION
Microcosm maintains a pair of methods for writing to `app.state`: `get` and `set`. This PR makes a change to `set` so that it first checks to see if a value has actually changed before overwriting it.