### PR TITLE
Throw error if push() called before start()

### DIFF
--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -11,6 +11,12 @@ import lifecycle   from './lifecycle'
 import merge       from './merge'
 import tag         from './tag'
 
+function throwIfError (error) {
+  if (error) {
+    throw error
+  }
+}
+
 /**
  * Microcosm
  * @class
@@ -42,6 +48,7 @@ function Microcosm (options) {
 
 Microcosm.prototype = {
   constructor: Microcosm,
+  started: false,
 
   /**
    * Calculates initial state. This is no longer used internally,
@@ -95,6 +102,8 @@ Microcosm.prototype = {
    * @return {any} The result of the action
    */
   push(action, params, callback) {
+    if (!this.started) throw new Error('Cannot push: Did you forget to call app.start()?')
+
     let transaction = new Transaction(tag(action))
 
     this.lifecycle(lifecycle.willOpenTransaction, transaction)
@@ -226,7 +235,8 @@ Microcosm.prototype = {
    * @param {function} [callback] - A callback to execute after the application starts
    * @return {Microcosm} The invoking instance of Microcosm
    */
-  start(callback) {
+  start(callback=throwIfError) {
+    this.started = true
     install(this.plugins, callback)
     return this
   }

--- a/src/install.js
+++ b/src/install.js
@@ -7,12 +7,6 @@
  * of a Microcosm.
  */
 
-function defaultCallback (error) {
-  if (error) {
-    throw error
-  }
-}
-
 function ensureCallback (plugin) {
   // Plugins that follow register(app, options, next) are asynchronous
   if (plugin.register.length >= 3) {
@@ -39,6 +33,6 @@ function installPlugin (next, plugin) {
   }
 }
 
-export default function (plugins, callback=defaultCallback) {
+export default function (plugins, callback) {
   return plugins.reduceRight(installPlugin, callback)()
 }

--- a/test/Microcosm-test.js
+++ b/test/Microcosm-test.js
@@ -106,6 +106,14 @@ describe('Microcosm', function() {
     })
   })
 
+  it ('throws an error if asked to push before start() has been called', function() {
+    let app = new Microcosm()
+
+    assert.throws(function() {
+      app.push(() => {})
+    }, /Cannot push: Did you forget to call app.start()?/)
+  })
+
   context('when a microcosm plugin passes an error', function() {
     let app   = new Microcosm()
     let error = 'This error should exist!'
@@ -118,5 +126,4 @@ describe('Microcosm', function() {
       assert.throws(() => app.start(), error)
     })
   })
-
 })


### PR DESCRIPTION
Adds a helpful error to let you know you probably forgot to call `app.start()` if trying to push before doing so.