### PR TITLE
Precompile transactions for 3-5x performance

### DIFF
--- a/examples/simple-svg/app/components/Viget.jsx
+++ b/examples/simple-svg/app/components/Viget.jsx
@@ -1,26 +1,15 @@
 import React from 'react'
 
-export default React.createClass({
-  getDefaultProps() {
-    return {
-      title: 'Microcosm SVG Chart Example',
-      height: 300,
-      width: 250
-    }
-  },
+export default function Viget ({ circle }) {
+  var { cx, cy, r } = circle
 
-  render() {
-    var { title, width, height } = this.props
-    var { cx, cy, r } = this.props.circle
-
-    return (
-      <svg height={ height } width={ width } version="1.1">
-        <title>{ title }</title>
-        <g transform={ `translate(${ width * 0.5}, ${ height * 0.5 })` }>
-          <circle key="earth" r="25" fill="#1496bb" />
-          <circle key="moon" cx={ cx } cy={ cy } r={ r } fill="#f26d21" />
-        </g>
-      </svg>
-    )
-  }
-})
+  return (
+    <svg height="300" width="250" version="1.1">
+      <title>Microcosm SVG Chart Example</title>
+      <g transform="translate(125, 150)">
+        <circle key="earth" r="25" fill="#1496bb" />
+        <circle key="moon" cx={ cx } cy={ cy } r={ r } fill="#f26d21" />
+      </g>
+    </svg>
+  )
+}

--- a/src/Microcosm.js
+++ b/src/Microcosm.js
@@ -4,7 +4,7 @@ import History     from './plugins/history'
 import MetaStore   from './stores/meta'
 import State       from './plugins/state'
 import Transaction from './Transaction'
-import compile     from './compile'
+import memorize    from './memorize'
 import defaults    from './defaults'
 import dispatch    from './dispatch'
 import flatten     from './flatten'
@@ -96,7 +96,7 @@ Microcosm.prototype = {
 
   /**
    * Given an old state, an action type, and a payload, reduce through
-   * the registry (or compile it) for the given action type to determine
+   * the registry (or memorize it) for the given action type to determine
    * new state.
    *
    * @param state {object} The starting application state
@@ -107,7 +107,7 @@ Microcosm.prototype = {
    */
   dispatch(state, type, payload) {
     if (!this.registry[type]) {
-      this.registry[type] = compile(this.stores, type)
+      this.registry[type] = memorize(this.stores, type)
     }
 
     return dispatch(state, this.registry[type], payload)

--- a/src/compile.js
+++ b/src/compile.js
@@ -1,14 +1,6 @@
-/**
- * Send
- * Communicate an action to a store. This is how Microcosm determines
- * how transaction parameters should update state.
- */
-
 import { formatTag } from './tag'
-import { isFunction } from './type-checks'
-import { get } from './update'
 
-export default function send (key, store, state, type, payload) {
+function generate (key, store, type) {
   let handler = store[type]
 
   if (handler === undefined && store.register) {
@@ -21,5 +13,11 @@ export default function send (key, store, state, type, payload) {
     handler = registrations[type]
   }
 
-  return isFunction(handler) ? handler.call(store, get(state, key), payload, state) : handler
+  return handler
+}
+
+export default function compile (entries, type) {
+  return entries.map(function ([ key, store ]) {
+    return { key, store, handler: generate(key, store, type) }
+  })
 }

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -6,14 +6,13 @@
  * "What will change when I account for a transaction?"
  */
 
-import send from './send'
-import { set } from './update'
+import { get, set } from './update'
 
-let dispatch = function (stores, state, { active, payload, type }) {
-  if (!active) return state
+export default function dispatch (state, handlers, payload) {
+  for (var i = 0, size = handlers.length; i < size; i++) {
+    let { key, store, handler } = handlers[i]
 
-  for (var [ key, store ] of stores) {
-    var answer = send(key, store, state, type, payload)
+    let answer = typeof handler === 'function' ? handler.call(store, get(state, key), payload, state) : handler
 
     if (answer !== undefined) {
       state = set(state, key, answer)
@@ -22,5 +21,3 @@ let dispatch = function (stores, state, { active, payload, type }) {
 
   return state
 }
-
-export default dispatch

--- a/src/memorize.js
+++ b/src/memorize.js
@@ -1,6 +1,6 @@
 import { formatTag } from './tag'
 
-function generate (key, store, type) {
+function getHandler (key, store, type) {
   let handler = store[type]
 
   if (handler === undefined && store.register) {
@@ -16,8 +16,8 @@ function generate (key, store, type) {
   return handler
 }
 
-export default function compile (entries, type) {
+export default function memorize (entries, type) {
   return entries.map(function ([ key, store ]) {
-    return { key, store, handler: generate(key, store, type) }
+    return { key, store, handler: getHandler (key, store, type) }
   })
 }

--- a/src/plugins/history.js
+++ b/src/plugins/history.js
@@ -4,7 +4,6 @@
  */
 
 import Tree      from '../Tree'
-import dispatch  from '../dispatch'
 import lifecycle from '../lifecycle'
 
 const History = {
@@ -14,31 +13,31 @@ const History = {
     this.maxHistory = maxHistory
 
     app.history = new Tree()
-
-    app.push(lifecycle.willStart)
   },
 
-  shouldHistoryKeep(transaction) {
+  shouldHistoryKeep() {
     return this.maxHistory > 0 && this.app.history.size() <= this.maxHistory
   },
 
   clean(transaction) {
-    if (transaction.complete && this.shouldHistoryKeep(transaction) == false) {
-      this.cache = dispatch(this.app.stores, this.cache, transaction)
+    if (transaction.complete && this.shouldHistoryKeep() === false) {
+      this.cache = this.fold(this.cache, transaction)
       return true
     }
 
     return false
   },
 
+  fold(state, { active, type, payload }) {
+    return active ? this.app.dispatch(state, type, payload) : state
+  },
+
   /**
    * Rolls state forward, cleaning up any erroneous or completed actions.
    */
-  [lifecycle.willUpdate](app, state) {
-    let reducer = dispatch.bind(null, app.stores)
-
+  [lifecycle.willUpdate](app) {
     return app.history.prune(this.clean, this)
-                      .reduce(reducer, this.cache)
+                      .reduce(this.fold, this.cache, this)
   },
 
   [lifecycle.willOpenTransaction](app, transaction) {

--- a/src/plugins/state.js
+++ b/src/plugins/state.js
@@ -1,12 +1,14 @@
-import Transaction from '../Transaction'
-import dispatch    from '../dispatch'
-import lifecycle   from '../lifecycle'
-import merge       from '../merge'
+import lifecycle from '../lifecycle'
+import merge     from '../merge'
 
 const State = {
 
+  register(app) {
+    return app.push(lifecycle.willStart)
+  },
+
   [lifecycle.willStart](app) {
-    return dispatch(app.stores, {}, new Transaction(lifecycle.willStart, app.state))
+    return app.dispatch({}, lifecycle.willStart, app.state)
   },
 
   [lifecycle.willReset](app, data) {
@@ -18,11 +20,11 @@ const State = {
       return app.state
     }
 
-    return dispatch(app.stores, data, new Transaction(lifecycle.willDeserialize, data))
+    return app.dispatch(data, lifecycle.willDeserialize, data)
   },
 
   [lifecycle.willSerialize](app, state) {
-    return dispatch(app.stores, state, new Transaction(lifecycle.willSerialize, state))
+    return app.dispatch(state, lifecycle.willSerialize, state)
   }
 
 }

--- a/test/dispatch-test.js
+++ b/test/dispatch-test.js
@@ -1,22 +1,24 @@
 import Microcosm from '../src/Microcosm'
 import Transaction from '../src/Transaction'
-import dispatch from '../src/dispatch'
 import assert from 'assert'
 
 describe('dispatch', function() {
 
   it ('returns state if not active', function() {
-    let transaction = new Transaction('foo')
-    let store = {
+    var app = new Microcosm()
+
+    app.addStore({
       register() {
         return { foo: true }
       }
-    }
+    })
 
-    let state = {}
-    let next  = dispatch([ [ 'test', store ] ], state, new Transaction('test'))
+    app.start()
 
-    assert.equal(next, state)
+    let old  = app.state
+    let next = app.dispatch(app.state, new Transaction('test'))
+
+    assert.equal(next, old)
   })
 
   it ('does not mutate base state on prior dispatches', function() {

--- a/test/send-test.js
+++ b/test/send-test.js
@@ -1,7 +1,5 @@
 let Microcosm = require('../src/Microcosm')
-let Transaction = require('../src/Transaction')
 let assert = require('assert')
-let send = require('../src/send')
 let lifecycle = require('../src/lifecycle')
 
 describe('sending actions', function() {

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -58,4 +58,35 @@ describe('Stores', function() {
 
     assert(app.state.test)
   })
+
+  context('when a microcosm is pushes an action', function() {
+    let action = n => n
+
+    beforeEach(function(done) {
+      this.app = new Microcosm()
+      this.app.start()
+      this.app.push(action, null, done)
+    })
+
+    context ('and a new store is added', function() {
+
+      beforeEach(function() {
+        this.app.addStore('test', function() {
+          return {
+            [action]: () => true
+          }
+        })
+      })
+
+      context('and that action is pushed again', function () {
+        beforeEach(function(done) {
+          this.app.push(action, null, done)
+        })
+
+        it ('accounts for the new handler', function () {
+          assert.equal(this.app.state.test, true)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Currently, the slowest part of the Microcosm dispatch process is the invocation of the `register` method that Stores can implement to subscribe to an action:

```javascript
import userActions from 'actions/user'

const UserStore = {
    getInitialState() {
        return []
    },
    register() {
        // Runs every time an is dispatched
        return {
            [userActions.add]: (users, record) => users.concat(record)
        }
    }
}
```

This PR adds a registry to Microcosm instances that memoizes this process. 

```shell
# Before
Time to dispatch 5000 actions: 14.224ms
Pushed 10000 actions in 84.615ms (average of 0.0085ms)
```

```shell
# After
Time to dispatch 5000 actions: 3.667ms
Pushed 10000 actions in 49.937ms (average of 0.0050ms)
```

Pretty cool! The simple SVG example is able to get up to about 37,000 transactions before it dips below 30 FPS. If you didn't need animation-grade performance you could probably get as high as 50,000.