### PR TITLE
Reduce memory footprint even lower

### DIFF
--- a/benchmarks/dispatch-performance.js
+++ b/benchmarks/dispatch-performance.js
@@ -11,8 +11,8 @@ var Microcosm   = require('../dist/Microcosm')
 var Transaction = require('../dist/Transaction')
 var time        = require('microtime')
 
-var SIZE        = 10000
-var SAMPLES     = 500
+var SIZE        = 50000
+var SAMPLES     = 50
 
 var app = new Microcosm({ maxHistory: Infinity })
 
@@ -45,9 +45,11 @@ app.start()
  * `push` takes anywhere from 0.5ms to 15ms depending on the sample range.
  * This adds up to a very slow boot time!
  */
+var startMemory = process.memoryUsage().heapUsed
 for (var i = 0; i < SIZE; i++) {
   app.history.append(new Transaction(action, true))
 }
+var endMemory = process.memoryUsage().heapUsed
 
 /**
  * Warm up `::push()`
@@ -67,5 +69,7 @@ average /= SAMPLES
 
 var duration = (SIZE * (1000 / 60)) / (1000 * 60)
 
-console.log('Average time dispatch %s: %sms (%s samples)', SIZE, average.toFixed(2), SAMPLES)
-console.log("(%s minutes of recorded history)\n", duration.toFixed(2))
+console.log('%sms to dispatch %s actions (%s samples)', average.toFixed(2), SIZE, SAMPLES)
+console.log('- %smbs of memory', ((endMemory - startMemory) / 100000).toFixed(2))
+console.log("- %s minutes of history", duration.toFixed(2))
+console.log("") // New line

--- a/benchmarks/tree-performance.js
+++ b/benchmarks/tree-performance.js
@@ -4,7 +4,7 @@
 
 var Tree  = require(__dirname + '/../dist/Tree')
 var time  = require('microtime')
-var SIZE  = 10000
+var SIZE  = 50000
 var stats = { build: 0, root: 0, merge: 0, size: 0, prune: 0, memory: 0 }
 var tree  = new Tree()
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -26,7 +26,7 @@ Tree.prototype = {
   },
 
   append(item) {
-    this.focus  = Node(item, this.focus)
+    this.focus  = new Node(item, this.focus)
     this.anchor = this.anchor || this.focus
 
     return this.focus
@@ -75,16 +75,30 @@ Tree.prototype = {
 }
 
 function Node (value, parent) {
-  let node = { depth: 0, parent, value, children: [] }
+  this.parent = parent
+  this.value  = value
 
   if (parent) {
-    parent.children.push(node)
-    parent.next = node
+    this.depth   = parent.depth + 1
+    this.sibling = parent.next
 
-    node.depth = parent.depth + 1
+    parent.next = this
   }
+}
 
-  return node
+Node.prototype = {
+  depth: 0,
+
+  get children() {
+    var start = this.next
+    var nodes = []
+
+    while (start) {
+      nodes.push(start)
+      start = start.sibling
+    }
+    return nodes
+  }
 }
 
 export default Tree

--- a/test/Tree-test.js
+++ b/test/Tree-test.js
@@ -202,4 +202,44 @@ describe('Tree', function() {
 
     assert.equal(tree.root(), a)
   })
+
+  it ('can determine children', function() {
+    let tree = new Tree()
+    let a = tree.append('a')
+    let b = tree.append('b')
+
+    tree.checkout(a)
+
+    let c = tree.append('c')
+
+    assert.deepEqual(a.children.map(child => child.value), ['c', 'b'])
+  })
+
+  it ('does not lose children when checking out nodes on the left', function() {
+    let tree = new Tree()
+    let a = tree.append('a')
+    let b = tree.append('b')
+    let c = tree.append('c')
+
+    tree.checkout(b)
+
+    let d = tree.append('d')
+
+    assert.deepEqual(b.children.map(child => child.value), ['d', 'c'])
+  })
+
+  it ('does not lose children when checking out nodes on the right', function() {
+    let tree = new Tree()
+    let a = tree.append('a')
+    let b = tree.append('b')
+    let c = tree.append('c')
+
+    tree.checkout(b)
+
+    let d = tree.append('d')
+
+    tree.checkout(c)
+
+    assert.deepEqual(b.children.map(child => child.value), ['d', 'c'])
+  })
 })


### PR DESCRIPTION
Another fun one. Instead of storing the children of a history tree node as an array, I store it as a linked list on the existing node object. This prevents an array allocation. In order to calculate children, I've set up a getter that returns an arrayified version of this linked list.

The result is drastically reduced tree operations, and a much lighter memory footprint overall. Also, this improves performance so much that I increased the test benchmarks from 10,000 to 50,000 nodes.

## Before

```
Nodes  ::append()  ::root()  ::reduce(merge)  ::size()  ::prune()  Memory Growth
-----  ----------  --------  ---------------  --------  ---------  -------------
50000  0.0011ms    0.0250ms  11.77ms          0.03ms    3.98ms     0.812%

18.61ms to dispatch 50000 actions (50 samples)
- 162.70mbs of memory
- 13.89 minutes of history

Pushed 10000 actions in 40.222ms (average of 0.0040ms)
```

## After

```
Nodes  ::append()  ::root()  ::reduce(merge)  ::size()  ::prune()  Memory Growth
-----  ----------  --------  ---------------  --------  ---------  -------------
50000  0.0003ms    0.0220ms  7.08ms           0.03ms    1.69ms     1.086%

14.30ms to dispatch 50000 actions (50 samples)
- 58.43mbs of memory
- 13.89 minutes of history

Pushed 10000 actions in 38.643ms (average of 0.0039ms)
```

Memory growth is a _little_ higher because the linked list is a little sticker in GC. This isn't an issue because it does eventually clear, but the benchmark doesn't capture it. In either case, memory usage is 1/3 of the original.