### PR TITLE
Add valueOf option to Connect

### DIFF
--- a/src/addons/connect/index.js
+++ b/src/addons/connect/index.js
@@ -5,13 +5,15 @@ import hoistStatics   from 'hoist-non-react-statics'
 import shallowEqual   from './shallow-equal'
 
 const defaults = {
-  pure : true
+  pure    : true,
+  valueOf : false
 }
 
 export default function connect (mapStateToProps, options) {
   options = { ...defaults, ...options }
 
   const isPure = !!options.pure
+  const useValueOf = !!options.valueOf
 
   return function wrapWithConnect(WrappedComponent) {
 
@@ -56,7 +58,13 @@ export default function connect (mapStateToProps, options) {
         let nextState = {}
 
         for (let key in propMap) {
-          nextState[key] = propMap[key](this.app.state)
+          let answer = propMap[key](this.app.state)
+
+          if (useValueOf) {
+            answer = answer ? answer.valueOf() : answer
+          }
+
+          nextState[key] = answer
         }
 
         if (isPure && shallowEqual(this.state, nextState)) {

--- a/test/addons/connect-test.jsx
+++ b/test/addons/connect-test.jsx
@@ -251,4 +251,47 @@ describe('Connect Add-on', function() {
 
   })
 
+  describe('valueOf option', function () {
+
+    beforeEach(function (done) {
+      this.app = new Microcosm()
+      this.app.start(done)
+    })
+
+    it ('calls valueOf on getters when configured', function () {
+      this.app.replace({ name: 'Kurtz' })
+
+      let Namer = Connect(props => ({
+        name: state => ({ valueOf: () => state.name.toLowerCase() })
+      }), { valueOf: true })(({ name }) => (<p>{ name }</p>))
+
+      let namer = Test.renderIntoDocument(<Namer app={ this.app } />)
+
+      assert.equal(namer.state.name, 'kurtz')
+    })
+
+    it ('handles valueOf null', function () {
+      this.app
+
+      let Namer = Connect(props => ({
+        name: state => null
+      }), { valueOf: true })(({ name }) => (<p>{ name }</p>))
+
+      let namer = Test.renderIntoDocument(<Namer app={ this.app } />)
+
+      assert.equal(namer.state.name, null)
+    })
+
+    it ('handles valueOf undefined', function () {
+      this.app
+
+      let Namer = Connect(props => ({
+        name: state => undefined
+      }), { valueOf: true })(({ name }) => (<p>{ name }</p>))
+
+      let namer = Test.renderIntoDocument(<Namer app={ this.app } />)
+
+      assert.equal(namer.state.name, undefined)
+    })
+  })
 })


### PR DESCRIPTION
This is an experimental option for the Connect addon that enables it to
call `valueOf` on the value returned from a computed property. This
should open up a number of possibilities for writing query DSLs.

Basically, I want to support the following:

```javascript
var ViewModel = Connect(function (props) {
    return {
      users: Users.where({ job: 'Programmer' }).limit(10)
    }
})
```

In this example, we can provide perf optimizations to the query under the hood without exposing it to the user. 