### PR TITLE
Update linting process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,12 +19,13 @@
     "semi": 0
   },
   "plugins": [
-    "react"
+    "react",
+    "markdown"
   ],
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "rules": {
     "react/prop-types" : 0,
     "no-console": 0,
-    "no-unused-vars" : ["error", { "args": "none" }]
+    "no-unused-vars" : [2, { "args": "none" }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Microcosm
 
-![CircleCI](https://circleci.com/gh/vigetlabs/microcosm.svg?style=svg)
+[![CircleCI](https://img.shields.io/circleci/project/vigetlabs/microcosm.svg?maxAge=2592000)](https://circleci.com/gh/vigetlabs/microcosm)
+[![npm](https://img.shields.io/npm/v/microcosm.svg?maxAge=2592000)](https://www.npmjs.com/package/microcosm)
+[![npm](https://img.shields.io/npm/dm/microcosm.svg?maxAge=2592000)](https://www.npmjs.com/package/microcosm)
 
 Flux with central, isolated state.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/microcosm.js",
   "scripts": {
     "build": "make all",
-    "lint": "eslint {src,test,examples}/**/*.{js,jsx}",
+    "lint": "eslint {src,test,examples}/**",
     "test": "ava",
     "test:cov": "nyc --cache --reporter=html ava",
     "release": "make release"
@@ -55,11 +55,13 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-2": "6.11.0",
+    "babel-register": "6.11.6",
     "body-parser": "1.15.2",
     "console.table": "0.7.0",
     "elizabot": "0.0.2",
     "enzyme": "2.4.1",
     "eslint": "3.1.1",
+    "eslint-plugin-markdown": "1.0.0-beta.2",
     "eslint-plugin-react": "5.2.2",
     "express": "4.14.0",
     "happypack": "2.1.1",

--- a/src/getStoreHandlers.js
+++ b/src/getStoreHandlers.js
@@ -1,5 +1,7 @@
 function format (string) {
+  /*eslint-disable no-unused-vars*/
   const [ _, action, state ] = `${ string }`.match(/(\w*)\_\d+\_(\w*)/, ' ') || []
+  /*eslint-enable no-unused-vars*/
 
   return action ? `the ${ action } action's ${ state } state` : string
 }

--- a/test/tree.test.js
+++ b/test/tree.test.js
@@ -102,7 +102,7 @@ test('can get the previous node in the chain', t => {
 
 test('sets the root to null if checking out a null node', t => {
   const tree  = new Tree()
-  const first = tree.append(action)
+  tree.append(action)
 
   tree.checkout()
 


### PR DESCRIPTION
- Fixes a bug where eslint was run against no files.
- Adds linting of JS code in markdown documents.
- Fixes an unused var issue in a test.
- Ignores another unused var issue in a different test. (I can't find a
great way to ignore unused vars assigned to `_`.)