### PR TITLE
Add AJAX recipe to documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ start. Beyond that, check out [the example apps](../examples).
 ## Recipes
 
 1. [React Router](recipes/react-router.md)
+2. [AJAX](recipes/ajax.md)
 
 ## API
 

--- a/docs/recipes/ajax.md
+++ b/docs/recipes/ajax.md
@@ -41,10 +41,10 @@ app.push(getSite)
 
 ### How it works
 
-Microcosm will detect that a Promise was returned from the action
-creator and handle it in the following way:
+When Microcosm detects a Promise returned from an action
+creator, it handles it in the following way:
 
-1. Mark the action as open. This gives store handlers a way to
+1. Mark the action as `open`. This gives store handlers a way to
    subscribe to a loading state.
 2. On resolution, mark the action as `done` and update its payload to
    that of the resolved Promise.

--- a/docs/recipes/ajax.md
+++ b/docs/recipes/ajax.md
@@ -1,0 +1,127 @@
+# AJAX
+
+There are two ways to manage asynchronous requests in Microcosm:
+
+1. [Return a Promise](#return-a-promise)
+2. [Tap into the lower-level action API](#tap-into-the-lower-level-action-api)
+
+## Return a Promise
+
+Many AJAX libraries return Promises. In order to improve
+integration with these libraries, Microcosm provides default behaviors
+around Promises. Whenever an action creator returns a Promise, it will
+wait for that Promise to resolve/reject:
+
+```javascript
+// Run this code yourself at:
+// https://tonicdev.com/57ac614723722e17003526a7/57ac68df74054114008fbb19
+var Microcosm = require("microcosm")
+var request = require('superagent')
+
+var app = new Microcosm()
+
+function getSite () {
+  return request.get('http://code.viget.com/microcosm')
+}
+
+app.addStore('site', function () {
+  return {
+    [getSite.open]   : () => 'loading',
+    [getSite.failed] : () => 'failed',
+    [getSite.done]   : () => 'done'
+  }
+})
+
+app.on('change', function (state) {
+  console.log(state.site) // loading, done
+})
+
+app.push(getSite)
+```
+
+### How it works
+
+Microcosm will detect that a Promise was returned from the action
+creator and handle it in the following way:
+
+1. Mark the action as open. This gives store handlers a way to
+   subscribe to a loading state.
+2. On resolution, mark the action as `done` and update its payload to
+   that of the resolved Promise.
+3. On failure, mark the action as `failed` and update its payload to
+   the associated error.
+
+### Why did my loading state go away when the action completed?
+
+Microcosm's state management model enables easy clean up of loading
+states. Whenever the action moves from `open` to `done`, Microcosm
+re-executes all incomplete actions in the order they were
+pushed.
+
+To illustrate, when the action creator is first pushed into Microcosm,
+it inserts an action into Microcosm's historical ledger of all actions
+like:
+
+```
+1. ajax (open)
+```
+
+Microcosm then enumerates through this list, using store handlers to
+calculate application state. When the action completes, it moves into
+a `done` state:
+
+```
+1. ajax (done)
+```
+
+Again, Microcosm rolls forward through the history list, recalculating
+state for the application.
+
+Since the action is no longer in an `open` state, the
+resulting application state will be as though the loading store
+handler never fired. There's no cleanup.
+
+## Tap into the lower-level action API
+
+Promises are easy to use, but they have a couple of problems when
+representing HTTP requests. Cancellation is difficult, and progress
+updates are impossible.
+
+Returning a function from an action creator provides a way to tap into
+the lower level API for an action:
+
+```javascript
+// Run this code yourself
+// https://tonicdev.com/57ac614723722e17003526a7/57ac7db6a55ecf1200fa1e5c
+var request = require('superagent')
+
+var app = new Microcosm()
+
+function getSite () {
+  return function (action) {
+    action.open()
+
+    request.get('http://code.viget.com/microcosm').end(function(error, payload) {
+      if (error) {
+        action.reject(error)
+      } else {
+        action.close(payload)
+      }
+    })
+  }
+}
+
+app.addStore('site', function () {
+  return {
+    [getSite.open]   : () => 'loading',
+    [getSite.failed] : () => 'failed',
+    [getSite.done]   : () => 'done'
+  }
+})
+
+app.on('change', function (state) {
+  console.log(state.site)
+})
+
+app.push(getSite)
+```

--- a/docs/recipes/ajax.md
+++ b/docs/recipes/ajax.md
@@ -14,17 +14,17 @@ resolve/reject:
 
 ```javascript
 // Run this code yourself at:
-// https://tonicdev.com/57ac614723722e17003526a7/57ac68df74054114008fbb19
-var Microcosm = require("microcosm")
+// https://tonicdev.com/57ac614723722e17003526a7/57acbf88a55ecf1200fa3763
+var Microcosm = require('microcosm')
 var request = require('superagent')
 
-var app = new Microcosm()
+var repo = new Microcosm()
 
 function getSite () {
   return request.get('http://code.viget.com/microcosm')
 }
 
-app.addStore('site', function () {
+repo.addStore('site', function () {
   return {
     [getSite.open]   : () => 'loading',
     [getSite.failed] : () => 'failed',
@@ -32,11 +32,11 @@ app.addStore('site', function () {
   }
 })
 
-app.on('change', function (state) {
+repo.on('change', function (state) {
   console.log(state.site) // loading, done
 })
 
-app.push(getSite)
+repo.push(getSite)
 ```
 
 ### How it works
@@ -66,18 +66,18 @@ like:
 ```
 
 Microcosm then enumerates through this list, using store handlers to
-calculate application state. When the action completes, it moves into
-a `done` state:
+calculate repo state. When the action completes, it moves into a
+`done` state:
 
 ```
 1. ajax (done)
 ```
 
 Again, Microcosm rolls forward through the history list, recalculating
-state for the application.
+state for the repo.
 
 Since the action is no longer in an `open` state, the
-resulting application state will be as though the loading store
+resulting repo state will be as though the loading store
 handler never fired. There's no cleanup.
 
 ## Tap into the lower-level action API
@@ -91,10 +91,12 @@ the lower level API for an action:
 
 ```javascript
 // Run this code yourself
-// https://tonicdev.com/57ac614723722e17003526a7/57ac7db6a55ecf1200fa1e5c
+//
+https://tonicdev.com/57ac614723722e17003526a7/57acbfab74054114008fda70
+var Microcosm = require('microcosm')
 var request = require('superagent')
 
-var app = new Microcosm()
+var repo = new Microcosm()
 
 function getSite () {
   return function (action) {
@@ -110,7 +112,7 @@ function getSite () {
   }
 }
 
-app.addStore('site', function () {
+repo.addStore('site', function () {
   return {
     [getSite.open]   : () => 'loading',
     [getSite.failed] : () => 'failed',
@@ -118,9 +120,9 @@ app.addStore('site', function () {
   }
 })
 
-app.on('change', function (state) {
+repo.on('change', function (state) {
   console.log(state.site)
 })
 
-app.push(getSite)
+repo.push(getSite)
 ```

--- a/docs/recipes/ajax.md
+++ b/docs/recipes/ajax.md
@@ -55,8 +55,7 @@ creator, it handles it in the following way:
 
 Microcosm's state management model enables easy clean up of loading
 states. Whenever the action moves from `open` to `done`, Microcosm
-re-executes all incomplete actions in the order they were
-pushed.
+re-executes all outstanding actions in the order they were pushed.
 
 To illustrate, when the action creator is first pushed into Microcosm,
 it inserts an action into Microcosm's historical ledger of all actions

--- a/docs/recipes/ajax.md
+++ b/docs/recipes/ajax.md
@@ -7,10 +7,10 @@ There are two ways to manage asynchronous requests in Microcosm:
 
 ## Return a Promise
 
-Many AJAX libraries return Promises. In order to improve
-integration with these libraries, Microcosm provides default behaviors
-around Promises. Whenever an action creator returns a Promise, it will
-wait for that Promise to resolve/reject:
+Microcosm implements standard behaviors for Promise resolution;
+convenient for Promise based AJAX libraries. Whenever an action
+creator returns a Promise, it will wait for that Promise to
+resolve/reject:
 
 ```javascript
 // Run this code yourself at:


### PR DESCRIPTION
Easy enough. cc @ltk 

I haven't covered cancellation or progress. These are special cases that I want to give their own recipes. Thoughts?