### PR TITLE
Add setup method

### DIFF
--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -12,6 +12,19 @@ as [React](https://facebook.github.io/react/)).
 
 ## API
 
+### `setup()`
+
+Called whenever a Microcosm is instantiated. This provides a general
+purpose hook for adding stores and other setup behavior.
+
+```javscript
+class SolarSystem extends Microcosm {
+  setup() {
+    this.addStore('planets', Planets)
+  }
+}
+```
+
 ### `getInitialState()`
 
 Generates the starting state for a Microcosm instance. This is the

--- a/examples/react-router/app/todos.js
+++ b/examples/react-router/app/todos.js
@@ -4,9 +4,7 @@ import Lists     from './stores/lists'
 
 export default class Todos extends Microcosm {
 
-  constructor(options) {
-    super(options)
-
+  setup() {
     // 1. Lists
     this.addStore('lists', Lists)
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -40,7 +40,7 @@ export default class Microcosm extends Emitter {
     // Standard store reduction behaviors
     this.addStore(MetaStore)
 
-    // Microcosm is now ready. Call the initialize method
+    // Microcosm is now ready. Call the setup lifecycle method
     this.setup()
   }
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -39,6 +39,18 @@ export default class Microcosm extends Emitter {
 
     // Standard store reduction behaviors
     this.addStore(MetaStore)
+
+    // Microcosm is now ready. Call the initialize method
+    this.setup()
+  }
+
+  /**
+   * Called whenever a Microcosm is instantiated. This provides a
+   * more intentional preparation phase that does not require
+   * tapping into the constructor
+   */
+  setup() {
+    // NOOP
   }
 
   /**


### PR DESCRIPTION
Tapping into `super` within the constructor when extending Microcosm feels too low level. What do you think about adding a setup step? Personally, I think it indicates the intent much clearer.

Replaces:

```javascript
class SolarSystem extends Microcosm {
  constructor(options) {
    super(options)
    this.addStore('planets', Planets)
  }
}
```

With:

```javascript
class SolarSystem extends Microcosm {
  setup() {
    this.addStore('planets', Planets)
  }
}
```

This also eliminates a friction point: remembering to pass `options` into `super()`.