### PR TITLE
Do not aggressively throw on missing actions

### DIFF
--- a/src/getStoreHandlers.js
+++ b/src/getStoreHandlers.js
@@ -13,17 +13,9 @@ function getHandler (key, store, type) {
     const registrations = store.register()
 
     if (process.env.NODE_ENV !== 'production') {
-      if ('undefined' in registrations) {
-        throw new Error(`When dispatching ${ format(type) } to the ${ key } store, `
-                        + `we encountered an "undefined" attribute within register(). `
-                        + `This usually happens when an action is imported `
-                        + `from the wrong namespace, or by referencing an invalid `
-                        + `action state.`)
-      }
-
       if (type in registrations && registrations[type] === undefined) {
-        throw new Error(`The handler for "${ format(type) }" within a store for "${ key }" `
-                        + `is undefined. Check the register method for this store.`)
+        console.warn('The handler for "%s" within a store for "%s" is undefined. ' +
+                     'Check the register method for this store.', format(type), key)
       }
     }
 

--- a/test/helpers/console.js
+++ b/test/helpers/console.js
@@ -1,0 +1,36 @@
+/**
+ * In order to test warnings, record console output.
+ */
+
+const originals = {}
+const messages = {
+  log: [],
+  warn: [],
+  error: []
+}
+
+export default {
+
+  record() {
+    for (let key in messages) {
+      originals[key] = console[key]
+      console[key] = (...args) => messages[key].push([args])
+    }
+  },
+
+  count(key) {
+    if (key in messages === false) {
+      throw new Error(`console.${key} is not tracked. Please add it to "${ __filename}"`)
+    }
+
+    return messages[key].length
+  },
+
+  restore() {
+    for (let key in messages) {
+      console[key] = originals[key]
+      messages[key].length = 0
+    }
+  }
+
+}

--- a/test/helpers/console.js
+++ b/test/helpers/console.js
@@ -20,7 +20,7 @@ export default {
 
   count(key) {
     if (key in messages === false) {
-      throw new Error(`console.${key} is not tracked. Please add it to "${ __filename}"`)
+      throw new Error(`console.${key} is not tracked. Please add it to "${ __filename }."`)
     }
 
     return messages[key].length

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,5 +1,6 @@
 import test from 'ava'
 import Microcosm from '../src/microcosm'
+import console from './helpers/console'
 
 test('stores can be functions', t => {
   const repo = new Microcosm()
@@ -23,25 +24,11 @@ test('stores can be objects with lifecycle methods', t => {
   t.is(repo.state.key, true)
 })
 
-test('throws if a registry contains an undefined key', t => {
-  const repo = new Microcosm()
-
-  // This will throw when added to a store because it will dispatch
-  // "getInitialState"
-  const badStore = function() {
-    return {
-      [undefined]: n => n
-    }
-  }
-
-  t.throws(function() {
-    repo.addStore('test', badStore)
-  }, /\"undefined\" attribute within register/)
-})
-
-test('throws if a register handler is undefined', t => {
+test('warns if a register handler is undefined', t => {
   const repo = new Microcosm()
   const action = n => n
+
+  console.record()
 
   repo.addStore('key', function() {
     return {
@@ -49,7 +36,9 @@ test('throws if a register handler is undefined', t => {
     }
   })
 
-  t.throws(function() {
-    repo.push(action)
-  }, /Check the register method for this store/)
+  repo.push(action)
+
+  t.is(console.count('warn'), 1)
+
+  console.restore()
 })


### PR DESCRIPTION
Before this commit, there was an error in the way stores report missing
handlers. They would check for `undefined` within the `register()`
function, however actions now have extra states that are referenced as
properties. We can no longer make this check when dispatching.

One alternative would be to use a Proxy. In the meantime, this commit
removes the warning and reduces another error to a warning.

Fixes #133