### PR TITLE
Make stores more powerful

### DIFF
--- a/docs/api/stores.md
+++ b/docs/api/stores.md
@@ -64,6 +64,11 @@ var Planets = {
 }
 ```
 
+### `setup()`
+
+Setup runs right after a store is added to a Microcosm, but before it runs
+getInitialState. This is useful for one-time setup instructions.
+
 ### `serialize(state)`
 
 Allows a store to transform data before it leaves the system. It gives

--- a/docs/api/stores.md
+++ b/docs/api/stores.md
@@ -127,3 +127,44 @@ const Planets = {
 
 repo.push(Actions.add, { name: 'earth' }) // this will add Earth
 ```
+
+### `commit(next)`
+
+How should a store actually write to `repo.state`? This is useful for serializing a complex data structure, such as a `Map`, into form easier for public consumption:
+
+```javascript
+import Immutable from 'immutable'
+
+const Planets = {
+  getInitialState() {
+    return Immutable.Map()
+  },
+
+  commit(next) {
+    return Array.from(next.values())
+  }
+}
+```
+
+### `shouldCommit(next, last)`
+
+Based on the next and last state, should `commit` be called? Useful for
+custom change management behavior.
+
+```javascript
+import Immutable from 'immutable'
+
+const Planets = {
+  getInitialState() {
+    return Immutable.Map()
+  },
+
+  shouldCommit(next, last) {
+    return Immutable.is(next, last)
+  }
+
+  commit(next) {
+    return Array.from(next.values())
+  }
+}
+```

--- a/docs/recipes/immutable-js.md
+++ b/docs/recipes/immutable-js.md
@@ -1,0 +1,95 @@
+# ImmutableJS Integration
+
+1. [Immutable Everywhere](#immutable-everywhere)
+2. [Immutable in, Vanilla out](#immutable-in-vanilla-out)
+
+## Immutable Everywhere
+
+The most basic integration method is to simply use ImmutableJS:
+
+```javascript
+import Immutable from 'immutable'
+import actions from 'actions'
+
+const Store = {
+  getInitialState() {
+    return Immutable.Map()
+  },
+
+  add(state, record) {
+    return state.set(record.id, record)
+  },
+
+  remove(state, id) {
+    return state.remove(id)
+  },
+
+  register() {
+    return {
+      [actions.create]: this.add,
+      [actions.destroy]: this.remove
+    }
+  }
+}
+```
+
+## Immutable in, Vanilla out
+
+We've found it can be much simpler to expose vanilla JavaScript data to our
+presentation layer. Unfortunately, this tends to mitigates much of the benefit
+of immutable data. It also can impose penalties serializing between the two formats.
+
+It is worth walking through the phases of state a Microcosm works through in order
+to better understand how Microcosm accommodates this use case:
+
+1. *archive* - For performance, Microcosm purges old actions and writes their
+final result to a cache.
+2. *staging* - State before a making change. This is a preparatory state allowing
+stores the ability to transform data one last time before assigning it publicly.
+3. *state* - Publicaly available state. This is what is exposed via `repo.state`,
+
+Essentially, Microcosm can maintain ImmutableJS data structures internally, exposing
+plain JavaScript for public consumption. There are two key methods responsible for this:
+
+1. *commit* - A middleware function that dictates how a Store assigns to `repo.state`.
+2. *shouldCommit* - A predicate function that controls invocation of `commit`.
+
+In practice, this results in a small adjustment to the store described earlier:
+
+```javascript
+import Immutable from 'immutable'
+import actions from 'actions'
+
+const Store = {
+  getInitialState() {
+    return Immutable.Map()
+  },
+
+  shouldCommit(next, previous) {
+    return Immutable.is(next, previous) === false
+  },
+
+  commit(state) {
+    return Array.from(state.values())
+  },
+
+  add(state, record) {
+    return state.set(record.id, record)
+  },
+
+  remove(state, id) {
+    return state.remove(id)
+  },
+
+  register() {
+    return {
+      [actions.create]: this.add,
+      [actions.destroy]: this.remove
+    }
+  }
+}
+```
+
+Here we've added a `shouldCommit` that utilizes the `Immutable.is` equality check.
+Additionally, `commit` describes how `Immutable` should convert into a regular form.
+In this case, it will convert into an Array.

--- a/docs/recipes/immutable-js.md
+++ b/docs/recipes/immutable-js.md
@@ -42,17 +42,17 @@ of immutable data. It also can impose penalties serializing between the two form
 It is worth walking through the phases of state a Microcosm works through in order
 to better understand how Microcosm accommodates this use case:
 
-1. *archive* - For performance, Microcosm purges old actions and writes their
+1. **archive** - For performance, Microcosm purges old actions and writes their
 final result to a cache.
-2. *staging* - State before a making change. This is a preparatory state allowing
+2. **staging** - State before a making change. This is a preparatory state allowing
 stores the ability to transform data one last time before assigning it publicly.
-3. *state* - Publicaly available state. This is what is exposed via `repo.state`,
+3. **state** - Publicaly available state. This is what is exposed via `repo.state`,
 
 Essentially, Microcosm can maintain ImmutableJS data structures internally, exposing
 plain JavaScript for public consumption. There are two key methods responsible for this:
 
-1. *commit* - A middleware function that dictates how a Store assigns to `repo.state`.
-2. *shouldCommit* - A predicate function that controls invocation of `commit`.
+1. **commit** - A middleware function that dictates how a Store assigns to `repo.state`.
+2. **shouldCommit** - A predicate function that controls invocation of `commit`.
 
 In practice, this results in a small adjustment to the store described earlier:
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-react": "6.2.0",
     "express": "4.14.0",
     "happypack": "2.2.1",
+    "immutable": "3.8.1",
     "jsdom": "9.5.0",
     "json-loader": "0.5.4",
     "microcosm-debugger": "vigetlabs/microcosm-debugger",

--- a/src/getStoreHandlers.js
+++ b/src/getStoreHandlers.js
@@ -9,7 +9,7 @@ function format (string) {
 function getHandler (key, store, type) {
   let handler = store[type]
 
-  if (handler === undefined && store.register) {
+  if (handler === undefined) {
     const registrations = store.register()
 
     if (process.env.NODE_ENV !== 'production') {

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -122,7 +122,7 @@ export default class Microcosm extends Emitter {
       const last = update.get(state, key)
       const next = handler.call(store, last, payload)
 
-      state = update.set(state, key, store.set(last, next))
+      state = update.set(state, key, store.stage(last, next))
     }
 
     return state

--- a/src/store.js
+++ b/src/store.js
@@ -41,15 +41,15 @@ export default class Store {
 
   /**
   * This is the actual operation used to write state to a Microcosm.
-  * Normally this isn't overridden, but it is useful for writing custom
-  * store behavior.
+  * Normally this isn't overridden, but it is useful for staging custom
+  * store behavior. This is currently a private API.
   *
+  * @private
   * @param {object} state - The current application state
-  * @param {string} key - the key path to assign
   * @param {any} value - The value to assign to a key
   * @return {object} newState - The next state for the Microcosm instance
   */
-  set(last, next) {
+  stage(last, next) {
     return next
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -4,8 +4,6 @@
  * behavior. It can also be extended.
  */
 
-import update from './update'
-
 const EMPTY = {}
 
 export default class Store {

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,69 @@
+/**
+ * Store
+ * This is the base class with which all stores draw their common
+ * behavior. It can also be extended.
+ */
+
+import update from './update'
+
+const EMPTY = {}
+
+export default class Store {
+
+  /**
+   * Setup runs right after a store is added to a Microcosm, but before
+   * it rebases state to include the store's `getInitialState` value. This
+   * is useful for one-time setup instructions
+   */
+  setup() {
+    // NOOP
+  }
+
+  /**
+   * A default register function that just returns an empty object. This helps
+   * keep other code from branching.
+   */
+  register() {
+    // NOOP
+    return EMPTY
+  }
+
+  /**
+   * Given a next and previous state, should the value be committed
+   * to the next revision?
+   *
+   * @param {any} next - the next state
+   * @param {any} last - the last state
+   *
+   * @return {boolean} Should the state update?
+   */
+  shouldCommit(next, last) {
+    return true
+  }
+
+  /**
+  * This is the actual operation used to write state to a Microcosm.
+  * Normally this isn't overridden, but it is useful for writing custom
+  * store behavior.
+  *
+  * @param {object} state - The current application state
+  * @param {string} key - the key path to assign
+  * @param {any} value - The value to assign to a key
+  * @return {object} newState - The next state for the Microcosm instance
+  */
+  set(last, next) {
+    return next
+  }
+
+  /**
+   * A middleware method for determining what exactly is assigned to
+   * repo.state. This gives libraries such as ImmutableJS a chance to serialize
+   * into a primitive JavaScript form before being publically exposed.
+   *
+   * @param {any} next - The next state for the store
+   */
+  commit(next) {
+    return next
+  }
+
+}

--- a/test/custom-store.test.js
+++ b/test/custom-store.test.js
@@ -1,0 +1,66 @@
+import test from 'ava'
+import Store from '../src/Store'
+import Microcosm from '../src/microcosm'
+
+const create  = n => n
+const destroy = n => n
+
+class TestDomain extends Store {
+
+  getInitialState() {
+    return ['reset']
+  }
+
+  set(state, [operation, path, params]) {
+    switch (operation) {
+      case 'reset':
+        return {}
+      case 'add':
+        return { ...state, [path]: params }
+      case 'remove':
+        let next = {...state}
+        delete next[path]
+        return next
+    }
+
+    console.warn('Unexpected operation %s', operation)
+
+    return state
+  }
+
+  add(state, record) {
+    return ['add', record.id, record]
+  }
+
+  remove(state, id) {
+    return ['remove', id]
+  }
+
+  register() {
+    return {
+      [create]  : this.add,
+      [destroy] : this.remove
+    }
+  }
+}
+
+test('adds records', t => {
+  var repo = new Microcosm()
+
+  repo.addStore('users', TestDomain)
+
+  repo.push(create, { id: 'bill', name: 'Bill' })
+
+  t.is(repo.state.users.hasOwnProperty('bill'), true)
+})
+
+test('removes records', t => {
+  var repo = new Microcosm()
+
+  repo.addStore('users', TestDomain)
+
+  repo.push(create, { id: 'bill', name: 'Bill' })
+  repo.push(destroy, 'bill')
+
+  t.is(repo.state.users.hasOwnProperty('bill'), false)
+})

--- a/test/custom-store.test.js
+++ b/test/custom-store.test.js
@@ -11,7 +11,7 @@ class TestDomain extends Store {
     return ['reset']
   }
 
-  set(state, [operation, path, params]) {
+  stage(state, [operation, path, params]) {
     switch (operation) {
       case 'reset':
         return {}

--- a/test/custom-store.test.js
+++ b/test/custom-store.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import Store from '../src/Store'
+import Store from '../src/store'
 import Microcosm from '../src/microcosm'
 
 const create  = n => n

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -1,15 +1,6 @@
 import test from 'ava'
 import Microcosm from '../src/microcosm'
 
-test('returns state if there are no handlers', t => {
-  const repo = new Microcosm()
-  const old = repo.state
-
-  repo.push(n => n)
-
-  t.is(repo.state, old)
-})
-
 test('does not mutate base state on prior dispatches', t => {
   const repo = new Microcosm()
 

--- a/test/immutable-interop.test.js
+++ b/test/immutable-interop.test.js
@@ -1,0 +1,74 @@
+import test from 'ava'
+import Store from '../src/Store'
+import Microcosm from '../src/microcosm'
+
+const create  = n => n
+const destroy = n => n
+
+import Immutable from 'immutable'
+
+class TestDomain extends Store {
+
+  getInitialState() {
+    return Immutable.Map()
+  }
+
+  shouldCommit(next, previous) {
+    return Immutable.is(next, previous) === false
+  }
+
+  add(state, record) {
+    return state.set(record.id, record)
+  }
+
+  remove(state, id) {
+    return state.remove(id)
+  }
+
+  commit(state) {
+    return Array.from(state.values())
+  }
+
+  register() {
+    return {
+      [create]  : this.add,
+      [destroy] : this.remove
+    }
+  }
+}
+
+test('adds records', t => {
+  var repo = new Microcosm()
+
+  repo.addStore('users', TestDomain)
+
+  repo.push(create, { id: 1, name: 'Bill' })
+
+  t.is(repo.state.users[0].name, 'Bill')
+})
+
+test('removes records', t => {
+  var repo = new Microcosm()
+
+  repo.addStore('users', TestDomain)
+
+  repo.push(create, { id: 1, name: 'Bill' })
+  repo.push(destroy, 1)
+
+  t.is(repo.state.users.length, 0)
+})
+
+test('does not generate a new array if no state changes', t => {
+  var repo = new Microcosm()
+
+  repo.addStore('users', TestDomain)
+
+  repo.push(create, { id: 1, name: 'Bill' })
+  repo.push(destroy, 1)
+  var a = repo.state
+
+  repo.push(destroy, 1)
+  var b = repo.state
+
+  t.is(a.users, b.users)
+})

--- a/test/immutable-interop.test.js
+++ b/test/immutable-interop.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import Store from '../src/Store'
+import Store from '../src/store'
 import Microcosm from '../src/microcosm'
 
 const create  = n => n

--- a/test/mutation.test.js
+++ b/test/mutation.test.js
@@ -5,14 +5,16 @@ test.cb('writes to repo state', t => {
   const action = function() {}
   const repo = new Microcosm()
 
-  repo.addStore(function() {
-    return {
-      getInitialState() {
-        return { test: false }
-      },
-      [action](state) {
-        state.test = true
-        return state
+  repo.addStore({
+    getInitialState() {
+      return { test: false }
+    },
+    register() {
+      return {
+        [action](state) {
+          state.test = true
+          return state
+        }
       }
     }
   })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,18 +1,7 @@
 import test from 'ava'
 import Microcosm from '../src/microcosm'
+import Store from '../src/store'
 import console from './helpers/console'
-
-test('stores can be functions', t => {
-  const repo = new Microcosm()
-
-  repo.addStore('key', function() {
-    return {
-      getInitialState: () => true
-    }
-  })
-
-  t.is(repo.state.key, true)
-})
 
 test('stores can be objects with lifecycle methods', t => {
   const repo = new Microcosm()
@@ -30,9 +19,11 @@ test('warns if a register handler is undefined', t => {
 
   console.record()
 
-  repo.addStore('key', function() {
-    return {
-      [action]: undefined
+  repo.addStore('key', {
+    register() {
+      return {
+        [action]: undefined
+      }
     }
   })
 
@@ -41,4 +32,46 @@ test('warns if a register handler is undefined', t => {
   t.is(console.count('warn'), 1)
 
   console.restore()
+})
+
+test('can control if state should be committed', t => {
+  const repo = new Microcosm()
+  const add  = n => n
+
+  t.plan(1)
+
+  repo.addStore('count', {
+    getInitialState() {
+      return 0
+    },
+    shouldCommit(next, previous) {
+      return Math.round(next) !== Math.round(previous)
+    },
+    register() {
+      return {
+        [add]: (a, b) => a + b
+      }
+    }
+  })
+
+  var first = repo.state
+
+  repo.push(add, 0.1).onDone(function() {
+    t.is(repo.state.count, first.count)
+  })
+
+})
+
+test('stores have a setup step', t => {
+  const repo = new Microcosm()
+
+  t.plan(1)
+
+  class Counter extends Store {
+    setup() {
+      t.pass()
+    }
+  }
+
+  repo.addStore('count', Counter)
 })


### PR DESCRIPTION
I want to better support custom APIs for Stores and the use of complex data libraries such as ImmutableJS. To do that, stores need to be more powerful:

```javascript
class ImmutableStore extends Store {

  getInitialState() {
    return Immutable.Map()
  }

  shouldCommit(next, previous) {
    return Immutable.is(next, previous) === false
  }

  add(state, record) {
    return state.set(record.id, record)
  }

  remove(state, id) {
    return state.remove(id)
  }

  commit(state) {
    return Array.from(state.values())
  }

  register() {
    return {
      [create]  : this.add,
      [destroy] : this.remove
    }
  }
}
```

**What's new**:

This PR adds several new options to stores:

```
setup - A one time preparation method called right after a store is added
set - How should a store assign a value?
commit - How should a store expose a value publicly?
```

**Three state phases**

State is captured in three phases. Each stage solves a different problem:

1. **archive** - A cache of completed actions. Since actions will never change, writing them to an archive allows the actions to be disposed, improving dispatch efficiency.
2. **staged** - The "private" state, before writing for public consumption. Store may not operate on primitive (like ImmutableJS), this allows a store to work with complex data types while still exposing a primitive public state.
3. **state** -  Public state. The `willCommit` lifecycle method allows a store to transform private state before it changes. This is useful for turning something like Immutable.Map() or a linked-list into a primitive object or array.

**Pure mode**

Additionally microcosm can be `pure` mode, similarly to the Presenter. In this case, it will only assign a new state if is not shallowly equal.

I wrote up a few exploratory test cases. I might move them to the examples folder if it seems prudent. They don't necessarily have to be in the standard test suite.

**Outstanding ideas**

What do you think about:

1. Presenter "pure" mode should be inherited by it's associated Microcosm. It's still overridable as a prop.
2. Each store has a `shouldCommit` hook. Technically we don't even have to shallowEquals, we could just increment a revision number. We could even do this on a store-by-store level.
3. Stores can be classes now. This means they can have their own internal state. What do we think about that?
4. I don't feel 100% on these names, or that they are concise, and easy to accidentally override. Should we make them intentionally more verbose?