### PR TITLE
Warn when returning repo.state, allow viewmodel function

### DIFF
--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -60,6 +60,24 @@ planets from the Microcosm instance provided to it via the `repo`
 prop. This is available as state, which the Presenter can send into a
 child component.
 
+### Listening to all state changes
+
+While we do not recommend it for large projects, some times it's simply easier
+to subscribe to all repo changes. `viewModel` can also return a function, which
+will be called with state:
+
+```javascript
+class PlanetsPresenter extends Presenter {
+  viewModel(props) {
+    return state => state
+  }
+
+  render() {
+    return <p>{ this.state.planets.join(', ') }</p>
+  }
+}
+```
+
 ## Receiving Intents
 
 Though explicit, passing event callbacks down through a deep component

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -107,7 +107,14 @@ export default class Presenter extends Component {
    * @private
    */
   _updatePropMap (props) {
-    this.propMap = this.viewModel(props)
+    this.propMap = this.viewModel ? this.viewModel(props) : {}
+
+    if (this.repo && this.propMap === this.repo.state) {
+      console.warn("The view model for this presenter returned repo.state. " +
+                   "This method onlys run when a presenter is given new properties. " +
+                   "If you would like to subscribe to all state changes, return a " +
+                   "function like: `(state) => state`.")
+    }
   }
 
   /**
@@ -125,8 +132,13 @@ export default class Presenter extends Component {
    * @private
    */
   _getState () {
-    const nextState = {}
     const repoState = this._getRepoState()
+
+    if (typeof this.propMap === 'function') {
+      return this.propMap(repoState)
+    }
+
+    const nextState = {}
 
     for (let key in this.propMap) {
       const entry = this.propMap[key]

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -240,3 +240,37 @@ test('calling setState in setup does not raise a warning', t => {
 
   console.restore()
 })
+
+test('warns when setState in setup does not raise a warning', t => {
+  class MyPresenter extends Presenter {
+    viewModel() {
+      return this.repo.state
+    }
+    render() {
+      return <p>Test</p>
+    }
+  }
+
+  console.record()
+
+  mount(<MyPresenter repo={ new Microcosm() } />)
+
+  t.regex(console.last('warn'), /The view model for this presenter returned repo\.state/i)
+
+  console.restore()
+})
+
+test('allows functions to return from viewModel', t => {
+  class MyPresenter extends Presenter {
+    viewModel() {
+      return state => state
+    }
+    render() {
+      return <p>Test</p>
+    }
+  }
+
+  const el = mount(<MyPresenter repo={new Microcosm()} />)
+
+  t.is(el.state(), el.instance().repo.state)
+})

--- a/test/helpers/console.js
+++ b/test/helpers/console.js
@@ -14,8 +14,12 @@ export default {
   record() {
     for (let key in messages) {
       originals[key] = console[key]
-      console[key] = (...args) => messages[key].push([args])
+      console[key] = (...args) => messages[key].push([args.join(' ')])
     }
+  },
+
+  last(key) {
+    return messages[key][messages[key].length - 1]
   },
 
   count(key) {


### PR DESCRIPTION
Sometimes a presenter just wants to subscribe to all state changes. We can't just return `this.repo.state`, because the view model is only recalculated when a presenter receives new props.

So here's my solution: support returning a function that is given the current repo state:

```javascript
class MyPresenter extends Presenter {
  viewModel() {
    return state => state
  }
  render() {
    return <p>Test</p>
  }
}
```

Or, to quickly extract several keys:

```javascript
class MyPresenter extends Presenter {
  viewModel() {
    return ({ dogs, cats }) => ({ dogs, cats })
  }
  render() {
    return <p>Test</p>
  }
}
```

We'll also now warn if `this.repo.state` is returned from the view model. What do you think?