### PR TITLE
Consolidate provider

### DIFF
--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -217,8 +217,7 @@ export default class Presenter extends Component {
 }
 
 Presenter.propTypes = {
-  repo     : React.PropTypes.instanceOf(Microcosm),
-  children : React.PropTypes.element
+  repo : React.PropTypes.instanceOf(Microcosm)
 }
 
 Presenter.contextTypes = {

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -210,18 +210,15 @@ export default class Presenter extends Component {
     console.warn(`No presenter implements intent “${ intent }”.`)
   }
 
-  /**
-   * Presenters require a render method. This will throw an error unless
-   * implemented by a subclass.
-   */
   render () {
-    throw new Error('Presenter must implement a render method.')
+    return this.props.children ? React.Children.only(this.props.children) : null
   }
 
 }
 
 Presenter.propTypes = {
-  repo : React.PropTypes.instanceOf(Microcosm)
+  repo     : React.PropTypes.instanceOf(Microcosm),
+  children : React.PropTypes.element
 }
 
 Presenter.contextTypes = {

--- a/src/addons/provider.js
+++ b/src/addons/provider.js
@@ -1,5 +1,4 @@
-import Microcosm from '../microcosm'
-import React, { Component, Children } from 'react'
+import Presenter from './presenter'
 
 /**
  * Sets up the required context for a React component tree
@@ -15,21 +14,6 @@ import React, { Component, Children } from 'react'
  *   </Provider>
  * ), document.getElementById('repo'))
  */
-export default class Provider extends Component {
-  getChildContext() {
-    return { repo: this.props.repo }
-  }
+export default class Provider extends Presenter {
 
-  render() {
-    return Children.only(this.props.children)
-  }
-}
-
-Provider.propTypes = {
-  repo     : React.PropTypes.instanceOf(Microcosm).isRequired,
-  children : React.PropTypes.element.isRequired
-}
-
-Provider.childContextTypes = {
-  repo : React.PropTypes.instanceOf(Microcosm).isRequired
 }

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -14,8 +14,10 @@ const View = React.createClass({
   }
 })
 
-test('requires an implementation of a render method', t => {
-  t.throws(() => mount(<Presenter />), /implement a render method/)
+test('the default render implementation passes children', t => {
+  let wrapper = mount(<Presenter><p>Test</p></Presenter>)
+
+  t.is(wrapper.text(), 'Test')
 })
 
 test('receives intent events', t => {
@@ -208,10 +210,6 @@ test('does not update the view model when umounted', t => {
       t.pass()
       return {}
     }
-
-    render() {
-      return <View />
-    }
   }
 
   let repo = new Microcosm({ pure: false })
@@ -226,9 +224,6 @@ test('calling setState in setup does not raise a warning', t => {
   class MyPresenter extends Presenter {
     setup() {
       this.setState({ foo: 'bar' })
-    }
-    render() {
-      return <View />
     }
   }
 
@@ -246,9 +241,6 @@ test('warns when setState in setup does not raise a warning', t => {
     viewModel() {
       return this.repo.state
     }
-    render() {
-      return <p>Test</p>
-    }
   }
 
   console.record()
@@ -264,9 +256,6 @@ test('allows functions to return from viewModel', t => {
   class MyPresenter extends Presenter {
     viewModel() {
       return state => state
-    }
-    render() {
-      return <p>Test</p>
     }
   }
 

--- a/test/addons/provider.test.js
+++ b/test/addons/provider.test.js
@@ -1,0 +1,15 @@
+import test from 'ava'
+import Provider from '../../src/addons/provider'
+import Connect from '../../src/addons/connect'
+import Microcosm from '../../src/microcosm'
+import React from 'react'
+import {mount} from 'enzyme'
+
+test('injects an repo from context into the wrapped component', t => {
+  const repo    = new Microcosm()
+  const Child  = () => (<p>Test</p>)
+  const Parent = Connect()(Child)
+
+  const component = mount(<Provider repo={repo}><Parent /></Provider>)
+  t.is(component.find(Child).prop('repo'), repo)
+})


### PR DESCRIPTION
Instead of throwing an error by default, Presenters just pass along children (if they can). This sort of makes the `Provider` addon pointless. Should we kill it?