### PR TITLE
withIntent addon

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ start. Beyond that, check out [the example apps](../examples).
 
 1. [Presenter](api/presenter.md)
 2. [Form](api/form.md)
+3. [withIntent](api/with-intent.md)

--- a/docs/api/with-intent.md
+++ b/docs/api/with-intent.md
@@ -1,0 +1,47 @@
+# withIntent(Component)
+
+1. [Overview](#overview)
+2. [API](#api)
+
+## Overview
+
+A higher order component that can be used to connect a component deep
+within the component tree to its associated presenter. This is useful
+for requesting work from Presenters where passing down callbacks as
+props may otherwise be exhaustive.
+
+```javascript
+import React from 'react'
+import withIntent from 'microcosm/addons/with-intent'
+
+const Button = withIntent(function ({ send }) {
+  return (
+    <button onClick={() => send('hello-world')}>
+      Say hello!
+    </button>
+  )
+})
+```
+
+## Testing
+
+`withIntent` relies on the context setup by a Presenter. When testing,
+this isn't always available. To work around this, Components wrapped
+in `withIntent` can accept `send` as a prop:
+
+```javascript
+import React from 'react'
+import test from 'ava'
+import {mount} from 'enzyme'
+import Button from 'prior-example'
+
+test('it emits an intent when clicked', assert => {
+  assert.plan(1)
+
+  function assertion (intent) {
+    assert.is(intent, 'hello-world')
+  }
+
+  mount(<Button send={assertion}) />
+})
+```

--- a/src/addons/with-intent.js
+++ b/src/addons/with-intent.js
@@ -1,0 +1,21 @@
+/**
+ * Connect a component to the presenter tree
+ */
+
+import React from 'react'
+import merge from '../merge'
+
+export default function withIntent (Component, intent) {
+
+  function WithIntent (props, context) {
+    let send = props.send || context.send
+
+    return React.createElement(Component, merge({ send }, props))
+  }
+
+  WithIntent.contextTypes = WithIntent.propTypes = {
+    send: React.PropTypes.func
+  }
+
+  return WithIntent
+}

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -384,3 +384,22 @@ test('does not waste rendering on nested children', t => {
   mount(<Parent repo={ repo } />)
   repo.replace({ name: 'Billy Booster' })
 })
+
+test('remembers inline properties', t => {
+  const repo = new Microcosm()
+
+  class Subject extends Presenter {
+    state = {
+      test: true
+    }
+    viewModel() {
+      return {
+        prop: state => true
+      }
+    }
+  }
+
+  let wrapper = mount(<Subject repo={ repo } />)
+
+  t.is(wrapper.state('test'), true)
+})

--- a/test/addons/withIntent.test.js
+++ b/test/addons/withIntent.test.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+import React from 'react'
+import withIntent from '../../src/addons/with-intent'
+import {mount} from 'enzyme'
+
+test('extracts send from context', t => {
+  t.plan(1)
+
+  const Button = withIntent(function ({ send }) {
+    return (
+      <button type="button" onClick={() => send('intent')}>Click me</button>
+    )
+  })
+
+  const component = mount(<Button />, {
+    context: {
+      send: intent => t.is(intent, 'intent')
+    },
+    childContextTypes: {
+      send: React.PropTypes.func
+    }
+  })
+
+  component.simulate('click')
+})
+
+test('allows send to be overridden by a prop', t => {
+  t.plan(1)
+
+  const Button = withIntent(function ({ send }) {
+    return (
+      <button type="button" onClick={() => send('intent')}>
+        Click me
+      </button>
+    )
+  })
+
+  mount(<Button send={intent => t.is(intent, 'intent')}/>).simulate('click')
+})


### PR DESCRIPTION
We have a Form add-on that connects to Presenters. @cwmanning has been utilizing a `withIntent` higher-order component that is better suited for buttons, or other components:

```javascript
const DestroyButton = withIntent(function ({ send }) {
  return (
    <button onClick={() => send('destroy-thing')}>
      Nuke this thing
    </button>
  )
})

class Users extends Presenter {
  register() {
    return {
      'destroy-thing': repo => repo.push(destroyThing)
    }
  }

  render() {
    // Kind of silly, probably better to use a callback prop here, but imagine
    // this is deep in the component tree
    return <DestroyButton />
  }
}
```

## One Question

Should we be more restrictive with passing down send? Something like `withIntent("intent-name", Component)`. We could add extra validations to make sure the intents are connected properly, and it might avoid some goofy dynamic code:

```javascript
const DestroyButton = withIntent('destroy-thing', function ({ send }) {
  return (
    <button type="button" onClick={send}>
      Nuke this thing
    </button>
  )
})
```

I'm kind of partial to this, but I could see cases where you would want to switch intents. Still, I wonder for those cases how much of the associated component would also change based on that switch (like a menu toggle changing from open to close). In those cases, I'd rather just have two buttons.