### PR TITLE
Add view method and alias for viewModel

### DIFF
--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -198,6 +198,28 @@ class PlanetPresenter extends Presenter {
 If the Presenter is pure (passed in as either a prop or as an option to the
 associated repo), this will only update state if shallowly equal.
 
+### `model(props)`
+
+Alias for `viewModel`.
+
+### `view(model)`
+
+A special render method that is given the current result of
+`viewModel`.
+
+```javascript
+class Greeter extends Presenter {
+  model ({ greet })
+    return {
+      message: state => "Hello, " + greet
+    }
+  }
+  view ({ message }) {
+    return <p>{message}</p>
+  }
+}
+```
+
 ### register()
 
 Expose "intent" subscriptions to child components. This is used with the <Form />

--- a/examples/chatbot/app/presenters/chat.jsx
+++ b/examples/chatbot/app/presenters/chat.jsx
@@ -5,20 +5,20 @@ import { send }  from '../actions/messages'
 
 export default class ChatPresenter extends Presenter {
 
-  viewModel() {
-    return {
-      messages : state => state.messages
-    }
-  }
-
-  register() {
+  register () {
     return {
       sendChat : (repo, data) => repo.push(send, data)
     }
   }
 
-  render() {
-    return <Messenger messages={ this.state.messages } />
+  model () {
+    return {
+      messages : state => state.messages
+    }
+  }
+
+  view ({ messages }) {
+    return <Messenger messages={ messages } />
   }
 
 }

--- a/examples/painter/app/actions/pixels.js
+++ b/examples/painter/app/actions/pixels.js
@@ -1,3 +1,3 @@
-export function paint (x, y) {
-  return { x, y }
+export function paint (point) {
+  return point
 }

--- a/examples/painter/app/painter.js
+++ b/examples/painter/app/painter.js
@@ -2,9 +2,7 @@ import Microcosm from '../../../src/microcosm'
 import Pixels    from './domains/pixels'
 
 export default class Painter extends Microcosm {
-  constructor(options) {
-    super(options)
-
+  setup () {
     this.addDomain('pixels', Pixels)
   }
 }

--- a/examples/painter/app/presenters/workspace.jsx
+++ b/examples/painter/app/presenters/workspace.jsx
@@ -6,7 +6,7 @@ import {paint}   from '../actions/pixels'
 class Workspace extends Presenter {
   register () {
     return {
-      paint: (repo, point) => this.repo.push(paint, point)
+      paint: (repo, point) => repo.push(paint, point)
     }
   }
 

--- a/examples/painter/app/presenters/workspace.jsx
+++ b/examples/painter/app/presenters/workspace.jsx
@@ -4,21 +4,21 @@ import Canvas    from '../views/canvas'
 import {paint}   from '../actions/pixels'
 
 class Workspace extends Presenter {
+  register () {
+    return {
+      paint: (repo, point) => this.repo.push(paint, point)
+    }
+  }
 
-  viewModel() {
+  model () {
     return {
       pixels : state => state.pixels
     }
   }
 
-  paint(x, y) {
-    return this.repo.push(paint, x, y)
+  view ({ pixels }) {
+    return <Canvas pixels={pixels} />
   }
-
-  render() {
-    return <Canvas pixels={ this.state.pixels } onClick={ this.paint.bind(this) } />
-  }
-
 }
 
 export default Workspace

--- a/examples/painter/app/views/row.jsx
+++ b/examples/painter/app/views/row.jsx
@@ -1,18 +1,19 @@
 import React from 'react'
 import withIntent from '../../../../src/addons/with-intent'
 
-withIntent(function Cell ({ x, y, active, send }) {
+const Cell = function ({ x, y, active, onClick }) {
   const color = active ? 'black' : 'white'
-  const paint = () => send('paint', { x, y })
 
-  return <rect key={x} x={x} y={y} onClick={paint} fill={color} width="1" height="1"/>
-})
+  return (
+    <rect x={x} y={y} onClick={onClick} fill={color} width="1" height="1"/>
+  )
+}
 
-export default function Row ({ cells, y, onClick }) {
+export default withIntent(function Row ({ cells, y, send }) {
 
   return (
     <g key={ y }>
-      { cells.map((active, x) => Cell({ x, y, active, onClick })) }
+      { cells.map((active, x) => <Cell key={x} x={x} y={y} active={active} onClick={() => send('paint', {x, y})} />)}
     </g>
   )
-}
+})

--- a/examples/painter/app/views/row.jsx
+++ b/examples/painter/app/views/row.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import withIntent from '../../../../src/addons/with-intent'
 
-function Cell ({ x, y, active, onClick }) {
+withIntent(function Cell ({ x, y, active, send }) {
   const color = active ? 'black' : 'white'
+  const paint = () => send('paint', { x, y })
 
-  return <rect key={ x } x={ x } y={ y } onClick={ () => onClick(x, y) } fill={ color } width="1" height="1"/>
-}
+  return <rect key={x} x={x} y={y} onClick={paint} fill={color} width="1" height="1"/>
+})
 
 export default function Row ({ cells, y, onClick }) {
 

--- a/examples/painter/app/views/row.jsx
+++ b/examples/painter/app/views/row.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import withIntent from '../../../../src/addons/with-intent'
 
-const Cell = function ({ x, y, active, onClick }) {
+function Cell ({ x, y, active, onClick }) {
   const color = active ? 'black' : 'white'
 
   return (

--- a/examples/react-router/app/presenters/list-index.jsx
+++ b/examples/react-router/app/presenters/list-index.jsx
@@ -6,33 +6,23 @@ import Index     from '../views/lists/index'
 import { addList, removeList } from '../actions/lists'
 
 class ListIndex extends Presenter {
+  register () {
+    return {
+      addList    : (repo, params) => repo.push(addList, params),
+      removeList : (repo, params) => repo.push(removeList, params.id)
+    }
+  }
 
-  viewModel() {
+  model () {
     return {
       lists  : Query.all('lists'),
       counts : Query.count('lists', 'items', 'list')
     }
   }
 
-  register() {
-    return {
-      addList    : this.addList,
-      removeList : this.removeList
-    }
+  view ({ lists, counts }) {
+    return <Index lists={lists} counts={counts} />
   }
-
-  addList(repo, params) {
-    return repo.push(addList, params)
-  }
-
-  removeList(repo, params) {
-    return repo.push(removeList, params.id)
-  }
-
-  render() {
-    return <Index lists={ this.state.lists } counts={ this.state.counts } />
-  }
-
 }
 
 export default ListIndex

--- a/examples/react-router/app/presenters/list-show.jsx
+++ b/examples/react-router/app/presenters/list-show.jsx
@@ -6,13 +6,6 @@ import Show      from '../views/lists/show'
 import { addItem, removeItem } from '../actions/items'
 
 class ListShow extends Presenter {
-
-  viewModel({ params }) {
-    return {
-      list  : Query.get('lists', params.id),
-      items : Query.where('items', 'list', params.id)
-    }
-  }
   register() {
     return {
       addItem    : this.addItem,
@@ -28,10 +21,16 @@ class ListShow extends Presenter {
     return repo.push(removeItem, params.id)
   }
 
-  render() {
-    return <Show list={ this.state.list } items={ this.state.items } />
+  model ({ params }) {
+    return {
+      list  : Query.get('lists', params.id),
+      items : Query.where('items', 'list', params.id)
+    }
   }
 
+  view ({ list, items }) {
+    return <Show list={list} items={items} />
+  }
 }
 
 export default ListShow

--- a/examples/react-router/app/views/notfound.jsx
+++ b/examples/react-router/app/views/notfound.jsx
@@ -17,7 +17,7 @@ export default function NotFound ({ resource = 'Page' }) {
           removed or never existed.
         </p>
         <p className="spacious">
-          <Link to="/react-router">Try starting over from the beginning</Link>
+          <Link to="/">Try starting over from the beginning</Link>
         </p>
       </main>
     </div>

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import Microcosm from '../microcosm'
 import shallowEqual from '../shallow-equal'
+import merge from '../merge'
 
 /**
  * A general component abstraction for high-responsibility React
@@ -100,6 +101,14 @@ export default class Presenter extends Component {
    * @returns {Object} The properties to assign to state
    */
   viewModel (props) {
+    return this.model()
+  }
+
+  /**
+   * Alias for viewModel
+   */
+
+  model() {
     return {}
   }
 
@@ -210,8 +219,12 @@ export default class Presenter extends Component {
     console.warn(`No presenter implements intent “${ intent }”.`)
   }
 
-  render () {
+  view (model) {
     return this.props.children ? React.Children.only(this.props.children) : null
+  }
+
+  render () {
+    return this.view(merge({}, this.props, this.state))
   }
 
 }

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -101,15 +101,14 @@ export default class Presenter extends Component {
    * @returns {Object} The properties to assign to state
    */
   viewModel (props) {
-    return this.model()
+    return this.model(props)
   }
 
   /**
    * Alias for viewModel
    */
-
-  model() {
-    return {}
+  model(props) {
+    return state => state
   }
 
   /**

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -3,6 +3,8 @@ import Microcosm from '../microcosm'
 import shallowEqual from '../shallow-equal'
 import merge from '../merge'
 
+const EMPTY = {}
+
 /**
  * A general component abstraction for high-responsibility React
  * components that interact with non-presentational logic so that the
@@ -108,7 +110,7 @@ export default class Presenter extends Component {
    * Alias for viewModel
    */
   model(props) {
-    return state => state
+    return EMPTY
   }
 
   /**

--- a/src/addons/with-intent.js
+++ b/src/addons/with-intent.js
@@ -7,7 +7,7 @@ import merge from '../merge'
 
 export default function withIntent (Component, intent) {
 
-  function WithIntent (props, context) {
+  function WithIntent (props, context = {}) {
     let send = props.send || context.send
 
     return React.createElement(Component, merge({ send }, props))

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -273,21 +273,6 @@ test('allows functions to return from viewModel', t => {
   t.is(el.state(), el.instance().repo.state)
 })
 
-test('passes all state by default', t => {
-  class MyPresenter extends Presenter {
-    view ({ text }) {
-      return <p>{ text }</p>
-    }
-  }
-
-  const repo = new Microcosm()
-  const el = mount(<MyPresenter repo={repo} />)
-
-  repo.replace({ text: 'Space, the final frontier' })
-
-  t.is(el.text(), 'Space, the final frontier')
-})
-
 test('does not cause a re-render when shallowly equal and pure', t => {
   const repo = new Microcosm({ pure: true })
   let renders = 0

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -82,8 +82,8 @@ test('handles non-function view model bindings', t => {
         upper: name.toUpperCase()
       }
     }
-    render() {
-      return <p>{this.state.upper}</p>
+    view({ upper }) {
+      return <p>{upper}</p>
     }
   }
 
@@ -109,7 +109,7 @@ test('send bubbles up to parent presenters', t => {
         }
       }
     }
-    render() {
+    view () {
       return <Child />
     }
   }
@@ -139,7 +139,7 @@ test('runs an update function when it gets new props', t => {
     update(repo, props) {
       t.is(props.test, "bar")
     }
-    render() {
+    view() {
       return <View />
     }
   }
@@ -155,7 +155,7 @@ test('does not run an update function when it is pure and no props change', t =>
       throw new Error('Presenter update method should not have been called')
     }
 
-    render() {
+    view() {
       return <View />
     }
   }
@@ -173,7 +173,7 @@ test('always runs update when impure', t => {
       t.pass()
     }
 
-    render() {
+    view() {
       return <View />
     }
   }
@@ -191,7 +191,7 @@ test('inherits purity from repo', t => {
       t.pass()
     }
 
-    render() {
+    view() {
       return <View />
     }
   }
@@ -283,9 +283,9 @@ test('does not cause a re-render when shallowly equal and pure', t => {
     viewModel() {
       return { name: state => state.name }
     }
-    render() {
+    view ({ name }) {
       renders += 1
-      return <p>{ this.state.name }</p>
+      return <p>{ name }</p>
     }
   }
 
@@ -306,9 +306,9 @@ test('always re-renders impure repos', t => {
     viewModel() {
       return { name: state => state.name }
     }
-    render() {
+    view ({ name }) {
       renders += 1
-      return (<p>{ this.state.name }</p>)
+      return (<p>{ name }</p>)
     }
   }
 
@@ -323,13 +323,13 @@ test('recalculates the view model if the props are different', t => {
   repo.replace({ name: 'Kurtz' })
 
   class Namer extends Presenter {
-    viewModel(props) {
+    viewModel (props) {
       return {
         name: state => props.prefix + ' ' + state.name
       }
     }
-    render() {
-      return (<p>{ this.state.name }</p>)
+    view ({ name }) {
+      return (<p>{ name }</p>)
     }
   }
 
@@ -346,7 +346,7 @@ test('does not recalculate the view model if the props are the same', t => {
   t.plan(1)
 
   class Namer extends Presenter {
-    viewModel(props) {
+    viewModel (props) {
       t.pass()
       return {}
     }
@@ -363,20 +363,20 @@ test('does not waste rendering on nested children', t => {
   t.plan(2)
 
   class Child extends Presenter {
-    viewModel() {
+    viewModel () {
       return { name: state => state.name }
     }
-    render() {
+    view () {
       t.pass()
       return <p>{ this.state.name }</p>
     }
   }
 
   class Parent extends Presenter {
-    viewModel() {
+    viewModel () {
       return { name: state => state.name }
     }
-    render() {
+    view () {
       return <Child />
     }
   }
@@ -408,13 +408,13 @@ test('does not tear down other listeners', t => {
   const repo = new Microcosm()
 
   class Parent extends Presenter {
-    render() {
+    view () {
       return this.props.hide ? <p>Nothing</p> : this.props.children
     }
   }
 
   class Child extends Presenter {
-    render() {
+    view () {
       return <p>Hey</p>
     }
   }
@@ -424,4 +424,22 @@ test('does not tear down other listeners', t => {
   wrapper.setProps({ hide: true })
 
   t.is(repo._callbacks['$change'].length, 1)
+})
+
+test('model is an alias for viewModel', t => {
+  class HelloWorld extends Presenter {
+    model () {
+      return {
+        greeting: "Hello, world!"
+      }
+    }
+
+    view ({ greeting }) {
+      return <p>{ greeting }</p>
+    }
+  }
+
+  let wrapper = mount(<HelloWorld />)
+
+  t.is(wrapper.text(), 'Hello, world!')
 })

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -273,6 +273,21 @@ test('allows functions to return from viewModel', t => {
   t.is(el.state(), el.instance().repo.state)
 })
 
+test('passes all state by default', t => {
+  class MyPresenter extends Presenter {
+    view ({ text }) {
+      return <p>{ text }</p>
+    }
+  }
+
+  const repo = new Microcosm()
+  const el = mount(<MyPresenter repo={repo} />)
+
+  repo.replace({ text: 'Space, the final frontier' })
+
+  t.is(el.text(), 'Space, the final frontier')
+})
+
 test('does not cause a re-render when shallowly equal and pure', t => {
   const repo = new Microcosm({ pure: true })
   let renders = 0
@@ -427,10 +442,10 @@ test('does not tear down other listeners', t => {
 })
 
 test('model is an alias for viewModel', t => {
-  class HelloWorld extends Presenter {
-    model () {
+  class Hello extends Presenter {
+    model ({ place }) {
       return {
-        greeting: "Hello, world!"
+        greeting: "Hello, " + place + "!"
       }
     }
 
@@ -439,7 +454,7 @@ test('model is an alias for viewModel', t => {
     }
   }
 
-  let wrapper = mount(<HelloWorld />)
+  let wrapper = mount(<Hello place="world" />)
 
   t.is(wrapper.text(), 'Hello, world!')
 })


### PR DESCRIPTION
I think, hopefully, this is the final touch on `10.0.0`. This PR adds a special rendering method for Presenters: `view`. When implemented, it accepts the current view model:

```javascript
class Greeter extends Presenter {

  model ({ greeting })
    return {
      message: state => greeting + ", " + state.location
    }
  }

  view ({ message }) {
    return <p>{message}</p>
  }

}

const repo = new Microcosm()

repo.replace({ location: 'World' })

DOM.render(<Greeter repo={repo} greeting="Hello" />, el)
// "Hello, World"
```

I've also added an alias for `viewModel`: `model`.

I believe there is an improvement to ergonomics here, and that this eliminates some of the strangeness with accessing `this.state` to get at a view model in `render`.

Users will always still have the option to just use `render`.

---

#148 