### PR TITLE
Teardown, opposite of Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Flipped `shouldCommit`'s signature to `shouldCommit(last, next)` to
   be consistent with other store methods.
+- Added `Presenter::teardown`, the opposite of `Presenter::setup`
 
 ## 10.0.0-rc5
 

--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -173,10 +173,9 @@ new information.
 If pure (by default) this will only get called if properties are shallowly
 different.
 
-### `teardown()`
+### `teardown(repo, props)`
 
-Teardown subscriptions and other setup behavior. Only necessary if overriding
-`componentWillUnmount`.
+Runs when the presenter unmounts. Useful for tearing down subscriptions and other setup behavior.
 
 ### `model(props)`
 

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -61,8 +61,13 @@ export default class Presenter extends Component {
    * Teardown subscriptions and other behavior.
    *
    * @param {Microcosm} repo - The presenter's Microcosm instance
+   * @param {Object} props - The presenter's props
    */
-  teardown () {
+  teardown (repo, props) {
+    // NOOP
+  }
+
+  unsubscribe() {
     if (this.repo) {
       this.repo.off('change', this._listener)
     }
@@ -74,6 +79,7 @@ export default class Presenter extends Component {
 
   componentWillUnmount () {
     this.teardown()
+    this.unsubscribe()
   }
 
   componentWillReceiveProps (nextProps) {

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -78,7 +78,7 @@ export default class Presenter extends Component {
   }
 
   componentWillUnmount () {
-    this.teardown()
+    this.teardown(this.repo, this.props)
     this.unsubscribe()
   }
 

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -443,3 +443,15 @@ test('model is an alias for viewModel', t => {
 
   t.is(wrapper.text(), 'Hello, world!')
 })
+
+test('calls a teardown method when it unmounts', t => {
+  t.plan(1)
+
+  class Test extends Presenter {
+    teardown () {
+      t.pass()
+    }
+  }
+
+  mount(<Test />).unmount()
+})

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -455,3 +455,15 @@ test('calls a teardown method when it unmounts', t => {
 
   mount(<Test />).unmount()
 })
+
+test('teardown gets the last props', t => {
+  t.plan(1)
+
+  class Test extends Presenter {
+    teardown (repo, props) {
+      t.is(props.test, 'bar')
+    }
+  }
+
+  mount(<Test test="foo" />).setProps({ test: 'bar' }).unmount()
+})


### PR DESCRIPTION
Adds `teardown(repo, props)`. This is useful for reversing anything done in `setup()`

cc @cwmanning 