### PR TITLE
Setup easier testing for domain handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Flipped `shouldCommit`'s signature to `shouldCommit(last, next)` to
   be consistent with other store methods.
 - Added `Presenter::teardown`, the opposite of `Presenter::setup`
+- Added back `Microcosm::append` and made it a public API. It's simply
+  too useful for testing.
 
 ## 10.0.0-rc5
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ start. Beyond that, check out [the example apps](../examples).
 1. [React Router](recipes/react-router.md)
 2. [AJAX](recipes/ajax.md)
 3. [ImmutableJS](recipes/immutable-js.md)
-4. [Testing Intents](recipes/testing-intents.md)
+4. [Testing Domains](recipes/testing-domains.md)
+5. [Testing Intents](recipes/testing-intents.md)
 
 ## API
 

--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -31,6 +31,25 @@ Generates the starting state for a Microcosm instance. This is the
 result of dispatching `getInitialState` to all domains. It is
 pure; calling this function will not update state.
 
+### `append(action)`
+
+Appends an action to a Microcosm's history, however does not execute
+it. This is useful for testing store responses to a specific action.
+
+```javascript
+let action = repo.append(createPlanet)
+
+// Test that opening an action for a planet marks
+// that planet as loading
+action.open({ id: 'pluto' })
+assert.equal(repo.state.planets.pluto.loading, true)
+
+// And then test that closing the action moves marks
+// the planet as no longer loading
+action.close({ id: 'pluto' })
+assert.falsy(repo.state.planets.pluto.loading)
+```
+
 ### `push(action, ...parameters)`
 
 Resolves an action. Sends the result and any errors to a given error-first callback.

--- a/docs/recipes/testing-domains.md
+++ b/docs/recipes/testing-domains.md
@@ -1,0 +1,98 @@
+# Testing Domains
+
+1. [Overview](#overview)
+2. [Writing test](#writing-tests)
+
+## Overview
+
+Domains control how a repo's should update based upon the state of an
+action. Some times we just want to test the specific handler for a
+given action state.
+
+The challenge here is that pushing an action into a repo could trigger
+a side-effect that needs to be controlled for. For example, an action
+may fire an AJAX request to a server that simply does not exist in a
+unit testing environment.
+
+To address this issue, Microcosm provides an `append` method. `append`
+is different from `push` in that it adds a new action to history,
+however does not execute it the associated behavior.
+
+```
+let repo = new Microcosm()
+
+// this will send out an ajax request
+repo.push(ajaxyThing)
+
+// this will just add an action to history, but it
+// won't invoke `ajaxyThing`
+repo.append(ajaxyThing)
+```
+
+## Writing tests
+
+Using `append` makes it easy to write tests for domain handlers at
+precise moments within an action. Let's assume the following repo:
+
+```
+function getPlanets () {
+  return ajax.get('/planets')
+}
+
+const PlanetsDomain = {
+  getInitialState () {
+    return { loading: false, records: [] }
+  },
+
+  replace (state, records) {
+    return { ...state, records }
+  },
+
+  loading (state) {
+    return { ...state, loading: true }
+  },
+
+  register() {
+    return {
+      [getPlanets.done]: this.replace,
+      [getPlanets.open]: this.loading
+    }
+  }
+}
+
+class SolarSystem extends Microcosm {
+  setup() {
+    this.addStore('planets', Planets)
+  }
+}
+```
+
+Just to recap, this repo is configured to set a loading state while an
+ajax request reaches out to retrieve planet information from an API
+endpoint. When it finishes, it should replace the existing planet
+records with the new information.
+
+From here, we can write succinct tests for each behavior.
+
+```javascript
+test('it sets a loading state when pushing getPlanets', assert => {
+  const repo = new SolarSystem()
+
+  const action = repo.append(getPlanets)
+
+  action.open()
+
+  assert.equal(repo.state.planets.loading, true)
+})
+
+test('it sets a loading state when pushing getPlanets', assert => {
+  const repo = new SolarSystem()
+
+  const action = repo.append(getPlanets)
+
+  action.close([{ id: '1', name: 'Mercury' }])
+
+  assert.equal(repo.state.planets.loading, false)
+  assert.equal(repo.state.planets.records[0].name, 'Mercury')
+})
+```

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -169,6 +169,21 @@ export default class Microcosm extends Emitter {
   }
 
   /**
+   * Append an action to history and return it. This is used by push,
+   * but also useful for testing action states
+   *
+   * @param {Function} behavior - An action function
+   * @return {Action} action representation of the invoked function
+   */
+  append (behavior) {
+    const action = this.history.append(behavior)
+
+    action.on('change', this.rollforward, this)
+
+    return action
+  }
+
+  /**
    * Push an action into Microcosm. This will trigger the lifecycle for updating
    * state.
    *
@@ -177,9 +192,7 @@ export default class Microcosm extends Emitter {
    * @return {Action} action representation of the invoked function
    */
   push (behavior, ...params) {
-    const action = this.history.append(behavior)
-
-    action.on('change', this.rollforward, this)
+    const action = this.append(behavior)
 
     action.execute(...params)
 

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -1,5 +1,6 @@
 import test from 'ava'
 import Action from '../src/action'
+import Microcosm from '../src/microcosm'
 
 const identity = n => n
 
@@ -332,4 +333,24 @@ test('executes onCancel if the action is already cancelled', t => {
   }
 
   action.onCancel(() => t.pass())
+})
+
+test('actions can be tested in reverse', t => {
+  const repo = new Microcosm()
+  const identity = n => n
+
+  repo.addDomain('test', {
+    register () {
+      return {
+        [identity.open] : () => 'open',
+        [identity.done] : () => 'done'
+      }
+    }
+  })
+
+  repo.append(identity).open()
+  t.is(repo.state.test, 'open')
+
+  repo.append(identity).close()
+  t.is(repo.state.test, 'done')
 })


### PR DESCRIPTION
I just hit this on a project and thought it would be cool to provide a canonical answer for testing domain handlers:

```javascript
const repo = new Microcosm()
const identity = n => n

repo.addDomain('test', {
  register () {
    return {
      [identity.open] : () => 'open',
      [identity.done] : () => 'done'
    }
  }
})

repo.append(identity).open()
assert.equal(repo.state.test, 'open')

repo.append(identity).close()
assert.equal(repo.state.test, 'done')
```

1. Adds back `append()`. I removed it before, but this was a mistake. Let's officially support it.
2. Adds a testing recipe for domain handlers