### PR TITLE
Do not support string key access on domain dispatch

### DIFF
--- a/src/domains/meta.js
+++ b/src/domains/meta.js
@@ -9,11 +9,11 @@ import merge from '../merge'
 
 export default {
 
-  [lifecycle.willReset](_old, next) {
+  [lifecycle._willReset](_old, next) {
     return next
   },
 
-  [lifecycle.willReplace](old, next) {
+  [lifecycle._willReplace](old, next) {
     return merge({}, old, next)
   }
 

--- a/src/getDomainHandlers.js
+++ b/src/getDomainHandlers.js
@@ -1,4 +1,5 @@
 import update from './update'
+import lifecycle from './lifecycle'
 
 function format (string) {
   /*eslint-disable no-unused-vars*/
@@ -9,7 +10,7 @@ function format (string) {
 }
 
 function getHandler (key, domain, type) {
-  let handler = domain[type]
+  let handler = lifecycle.hasOwnProperty(type) ? domain[type] : undefined
 
   if (handler === undefined) {
     const registrations = domain.register(type)

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -5,9 +5,9 @@
  */
 
 export default {
-  willStart       : 'getInitialState',
-  willSerialize   : 'serialize',
-  willDeserialize : 'deserialize',
-  willReset       : '__willReset',
-  willReplace     : '__willReplace'
+  getInitialState : 'getInitialState',
+  serialize       : 'serialize',
+  deserialize     : 'deserialize',
+  _willReset      : '_willReset',
+  _willReplace    : '_willReplace'
 }

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -77,7 +77,7 @@ export default class Microcosm extends Emitter {
    * @return {Object} State object representing the initial state.
    */
   getInitialState () {
-    return this.dispatch({}, { type: lifecycle.willStart })
+    return this.dispatch({}, { type: lifecycle.getInitialState })
   }
 
   /**
@@ -250,7 +250,7 @@ export default class Microcosm extends Emitter {
    * @return {Action} action - An action representing the reset operation.
    */
   reset (state) {
-    return this.push(lifecycle.willReset, merge(this.getInitialState(), state))
+    return this.push(lifecycle._willReset, merge(this.getInitialState(), state))
   }
 
   /**
@@ -261,7 +261,7 @@ export default class Microcosm extends Emitter {
    * @return {Action} action - An action representing the replace operation.
    */
   replace (data) {
-    return this.push(lifecycle.willReplace, this.deserialize(data))
+    return this.push(lifecycle._willReplace, this.deserialize(data))
   }
 
   /**
@@ -276,7 +276,7 @@ export default class Microcosm extends Emitter {
       return {}
     }
 
-    return this.dispatch(payload, { type: lifecycle.willDeserialize, payload })
+    return this.dispatch(payload, { type: lifecycle.deserialize, payload })
   }
 
   /**
@@ -287,7 +287,7 @@ export default class Microcosm extends Emitter {
    * @return {Object} The serialized version of repo state.
    */
   serialize () {
-    return this.dispatch(this.staged, { type: lifecycle.willSerialize })
+    return this.dispatch(this.staged, { type: lifecycle.serialize })
   }
 
   /**

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -46,10 +46,22 @@ test('allows lifecycle methods as registered actions', t => {
   repo.addDomain('test', {
     register() {
       return {
-        [lifecycle.willStart]: () => 'test'
+        [lifecycle.getInitialState]: () => 'test'
       }
     }
   })
 
   t.is(repo.state.test, 'test')
+})
+
+test('does not trigger on implemented methods', t => {
+  const repo = new Microcosm()
+
+  repo.addDomain('test', {
+    test() {
+      throw new Error("Should not have invoked test method")
+    }
+  })
+
+  repo.push('test')
 })


### PR DESCRIPTION
Basically don't let this happen:

```javascript
const repo = new Microcosm()

repo.addDomain('test', {
  test() {
      console.log("bad bad bad!")
  }
})

repo.push('test')
```

This is important because I want to support broadcasting actions as intents within `withIntent` and presenters.
