### PR TITLE
Add deserialize option to patch and reset

### DIFF
--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -58,13 +58,13 @@ Resolves an action. Sends the result and any errors to a given error-first callb
 repo.push(createPlanet, { name: 'Merkur' })
 ```
 
-### `reset(data, deserialize)`
+### `reset(data, deserialize?)`
 
 Resets state to the result of `Microcosm::getInitialState()`. If the
 first argument is provided, it will merge into this value. If the second
 argument is true, Microcosm will call `deserialize` on the data.
 
-### `patch(data, deserialize)`
+### `patch(data, deserialize?)`
 
 Merges a data payload into the existing state. If the second argument
 is true, Microcosm will call `deserialize` on the data.

--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -58,16 +58,16 @@ Resolves an action. Sends the result and any errors to a given error-first callb
 repo.push(createPlanet, { name: 'Merkur' })
 ```
 
-### `reset (state)`
+### `reset(data, deserialize)`
 
-Resets state to the result of calling `getInitialState()`. Optionally
-folds on a provided state object.
+Resets state to the result of `Microcosm::getInitialState()`. If the
+first argument is provided, it will merge into this value. If the second
+argument is true, Microcosm will call `deserialize` on the data.
 
-### `patch(state)`
+### `patch(data, deserialize)`
 
-Partially merge in a piece of repo state. This function is great for
-bootstrapping data when rendering from the server. It will not blow
-away keys that haven't been provided.
+Merges a data payload into the existing state. If the second argument
+is true, Microcosm will call `deserialize` on the data.
 
 ```javascript
 repo.patch({

--- a/src/history.js
+++ b/src/history.js
@@ -149,19 +149,11 @@ export default class History {
       // Point the base to the next node
       this.root = this.root.next
 
-      // Disconnect the pointer to the parent so GC can clean up
-      // disposable actions
-      root.parent  = null
-
-      // Similarly, the base has no siblings
-      root.sibling = null
-
-      // Disconnect the old root from the current
-      root.next = null
+      root.teardown()
     }
 
     if (this.size <= 0) {
-      this.root  = null
+      this.root = null
       this.head = null
       this.focus = null
     }

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -277,10 +277,15 @@ export default class Microcosm extends Emitter {
    * on to the result of `getInitialState()`.
    *
    * @param {Object} state - A new state object to apply to the instance
+   * @param {Object} deserialize - Should the data be deserialized?
    * @return {Action} action - An action representing the reset operation.
    */
-  reset (state) {
-    return this.push(lifecycle._willReset, merge(this.getInitialState(), state))
+  reset (data, deserialize) {
+    if (deserialize === true) {
+      data = this.deserialize(data)
+    }
+
+    return this.push(lifecycle._willReset, merge(this.getInitialState(), data))
   }
 
   /**
@@ -288,15 +293,20 @@ export default class Microcosm extends Emitter {
    * processed state object.
    *
    * @param {Object} data - A raw state object to deserialize and apply to the instance
+   * @param {Object} deserialize - Should the data be deserialized?
    * @return {Action} action - An action representing the patch operation.
    */
-  patch (data) {
+  patch (data, deserialize) {
+    if (deserialize === true) {
+      data = this.deserialize(data)
+    }
+
     return this.push(lifecycle._willPatch, data)
   }
 
   replace (state) {
-    console.warn('repo.replace has been deprecated. Please use repo.patch.')
-    return this.patch(this.deserialize(state))
+    console.warn('Microcosm::replace has been deprecated. Please use repo.patch(state, true).')
+    return this.patch(state, true)
   }
 
   /**

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -9,300 +9,7 @@ test('accommodates string actions', function () {
   expect(action.type).toBe('test')
 })
 
-test('initially returns no type', function () {
-  const action = new Action(identity)
-
-  expect(action.type).toBe(null)
-})
-
-test('is toggleable', function () {
-  const action = new Action(identity)
-
-  action.open()
-
-  action.toggle()
-  expect(action.is('disabled')).toBeTruthy()
-
-  action.toggle()
-  expect(action.is('disabled')).toBeFalsy()
-})
-
-test('returns no type when disabled', function () {
-  const action = new Action(identity)
-
-  action.toggle()
-
-  expect(action.type).toBe(null)
-})
-
-test('preserves other states when disabled', function () {
-  const action = new Action(identity)
-
-  action.resolve()
-  action.toggle()
-
-  expect(action.is('done')).toBe(true)
-})
-
-test('exposes a cancelled type when cancelled', function () {
-  const action = new Action(identity)
-
-  action.cancel()
-
-  expect(action.type).toBe(identity.cancelled)
-})
-
-test('becomes disposable when cancelled', function () {
-  const action = new Action(identity)
-
-  action.cancel()
-
-  expect(action.is('disposable')).toBe(true)
-})
-
-test('exposes a error type when rejected', function () {
-  const action = new Action(identity)
-
-  action.reject()
-
-  expect(action.type).toBe(identity.error)
-})
-
-test('exposes an open type when opened', function () {
-  const action = new Action(identity)
-
-  action.open()
-
-  expect(action.type).toBe(identity.open)
-})
-
-test('exposes a loading type when in progress', function () {
-  const action = new Action(identity)
-
-  action.send()
-
-  expect(action.type).toBe(identity.loading)
-})
-
-test('exposes a done type when completed', function () {
-  const action = new Action(identity)
-
-  action.resolve()
-
-  expect(action.type).toBe(identity.done)
-})
-
-test('listens to progress updates', function () {
-  const action = new Action(identity)
-  const fn = jest.fn()
-
-  action.onUpdate(fn)
-  action.send(true)
-
-  expect(fn).toHaveBeenCalledWith(true)
-})
-
-test('listens to failures', function () {
-  const action = new Action(identity)
-  const fn = jest.fn()
-
-  action.onError(fn)
-  action.reject(true)
-
-  expect(fn).toHaveBeenCalledWith(true)
-})
-
-test('immediately invokes onError if the action already failed', function () {
-  const action = new Action(identity)
-  const fn = jest.fn()
-
-  action.reject(true)
-  action.onError(fn)
-
-  expect(fn).toHaveBeenCalledWith(true)
-})
-
-test('listens to completion', function () {
-  const action = new Action(identity)
-
-  action.onDone(payload => {
-    expect(payload).toBe(true)
-  })
-
-  return action.resolve(true)
-})
-
-test('immediately invokes onDone if the action already closed', (done) => {
-  const action = new Action(identity)
-
-  action.resolve(true)
-
-  action.onDone(payload => {
-    expect(payload).toBe(true)
-    done()
-  })
-})
-
-test('immediately invokes onError if the action already failed', (done) => {
-  const action = new Action(identity)
-
-  action.reject(true)
-
-  action.onError(payload => {
-    expect(payload).toBe(true)
-    done()
-  })
-})
-
-test('triggers an open event when it opens', (done) => {
-  const action = new Action(identity)
-
-  action.once('open', function (body) {
-    expect(body).toBe(3)
-    done()
-  })
-
-  action.open(3)
-})
-
-test('triggers an update event when it sends', (done) => {
-  const action = new Action(identity)
-
-  action.once('update', function (body) {
-    expect(body).toBe(3)
-    done()
-  })
-
-  action.send(3)
-})
-
-test('triggers a done event when it resolves', (done) => {
-  const action = new Action(identity)
-
-  action.once('done', function (body) {
-    expect(body).toBe(3)
-    done()
-  })
-
-  action.resolve(3)
-})
-
-test('triggers a error event when it is rejected', (done) => {
-  const action = new Action(identity)
-
-  action.once('error', function (reason) {
-    expect(reason).toBe(404)
-    done()
-  })
-
-  action.reject(404)
-})
-
-test('triggers a cancel event when it is cancelled', (done) => {
-  const action = new Action(identity)
-
-  action.once('cancel', () => done())
-  action.cancel()
-})
-
-test('actions are disabled when first created', function () {
-  const action = new Action(identity)
-
-  expect(action.is('disabled')).toBe(true)
-})
-
-test('actions are no longer disabled when opened', function () {
-  const action = new Action(identity)
-
-  action.open(true)
-
-  expect(action.is('disabled')).toBe(false)
-  expect(action.is('open')).toBe(true)
-})
-
-test('actions are no longer open when in progress', function () {
-  const action = new Action(identity)
-
-  action.open(true)
-  action.send(true)
-
-  expect(action.is('open')).toBe(false)
-  expect(action.is('loading')).toBe(true)
-})
-
-test('actions are no loading open when they complete', function () {
-  const action = new Action(identity)
-
-  action.open(true)
-  action.send(true)
-  action.resolve(true)
-
-  expect(action.is('loading')).toBe(false)
-  expect(action.is('done')).toBe(true)
-})
-
-test('actions are disposable when they resolve', function () {
-  const action = new Action(identity)
-
-  action.resolve(true)
-
-  expect(action.is('disposable')).toBe(true)
-})
-
-test('actions are disposable when they fail', function () {
-  const action = new Action(identity)
-
-  action.reject(true)
-
-  expect(action.is('disposable')).toBe(true)
-})
-
-test('actions are disposable when they are cancelled', function () {
-  const action = new Action(identity)
-
-  action.cancel(true)
-
-  expect(action.is('disposable')).toBe(true)
-})
-
-test('actions interop with promises', function () {
-  const action = new Action(identity)
-
-  action.resolve('Test')
-
-  return action.then(result => expect(result).toBe('Test'))
-})
-
-test('cancel can be subscribed to', (done) => {
-  const action = new Action(identity)
-
-  action.onCancel(() => done())
-
-  action.cancel()
-})
-
-test('onCancel is a one time binding', (done) => {
-  const action = new Action(identity)
-
-  action.onCancel(() => done())
-
-  action.cancel()
-  action.cancel()
-})
-
-test('executes onCancel if the action is already cancelled', (done) => {
-  const action = new Action(identity)
-
-  action.cancel()
-
-  action.on = function() {
-    throw new Error('Should not have subscribed cancel. Action already cancelled.')
-  }
-
-  action.onCancel(() => done())
-})
-
-test('actions can be tested in reverse', function () {
+test('actions can be tested externally', function () {
   const repo = new Microcosm()
   const identity = n => n
 
@@ -337,4 +44,353 @@ test('throws if given an object', function () {
 
 test('does not throw if given null', function () {
   expect(() => new Action(null)).toThrow()
+})
+
+test('removes all listeners when torn down', function () {
+  const action = new Action(identity)
+  const callback = jest.fn()
+
+  action.on('done', callback)
+
+  action.teardown()
+  action.resolve()
+
+  expect(callback).not.toHaveBeenCalled()
+})
+
+describe('open state', function () {
+
+  test('exposes an open type when opened', function () {
+    const action = new Action(identity)
+
+    action.open()
+
+    expect(action.type).toBe(identity.open)
+  })
+
+  test('triggers an open event when it opens', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.once('open', callback)
+    action.open(3)
+
+    expect(callback).toHaveBeenCalledWith(3)
+  })
+
+  test('actions are no longer disabled when opened', function () {
+    const action = new Action(identity)
+
+    action.open(true)
+
+    expect(action.is('disabled')).toBe(false)
+    expect(action.is('open')).toBe(true)
+  })
+
+})
+
+describe('progress state', function () {
+
+  test('exposes a loading type when in progress', function () {
+    const action = new Action(identity)
+
+    action.send()
+
+    expect(action.type).toBe(identity.loading)
+  })
+
+  test('listens to progress updates', function () {
+    const action = new Action(identity)
+    const fn = jest.fn()
+
+    action.onUpdate(fn)
+    action.send(true)
+
+    expect(fn).toHaveBeenCalledWith(true)
+  })
+
+  test('does not trigger onUpdate if in progress', function () {
+    const action = new Action(identity)
+    const fn = jest.fn()
+
+    action.send(true)
+    action.onUpdate(fn)
+
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  test('actions are no longer open when in progress', function () {
+    const action = new Action(identity)
+
+    action.open(true)
+    action.send(true)
+
+    expect(action.is('open')).toBe(false)
+    expect(action.is('loading')).toBe(true)
+  })
+
+  test('triggers an update event when it sends', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.once('update', callback)
+    action.send(3)
+
+    expect(callback).toHaveBeenCalledWith(3)
+  })
+
+})
+
+describe('disabled state', function () {
+
+  test('actions are disabled when first created', function () {
+    const action = new Action(identity)
+
+    expect(action.is('disabled')).toBe(true)
+  })
+
+  test('actions return no type when disabled', function () {
+    const action = new Action(identity)
+
+    action.resolve()
+    action.toggle()
+
+    expect(action.type).toBe(null)
+  })
+
+  test('preserves other states when disabled', function () {
+    const action = new Action(identity)
+
+    action.resolve()
+    action.toggle()
+
+    expect(action.is('done')).toBe(true)
+  })
+
+  test('is toggleable', function () {
+    const action = new Action(identity)
+
+    action.resolve()
+    expect(action.is('disabled')).toBe(false)
+
+    action.toggle()
+    expect(action.is('disabled')).toBe(true)
+  })
+
+  test('returns no type when disabled', function () {
+    const action = new Action(identity)
+
+    action.toggle()
+
+    expect(action.type).toBe(null)
+  })
+
+})
+
+describe('resolved state', function () {
+
+  test('exposes a done type when completed', function () {
+    const action = new Action(identity)
+
+    action.resolve()
+
+    expect(action.type).toBe(identity.done)
+  })
+
+  test('triggers a done event when it resolves', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.once('done', callback)
+    action.resolve(3)
+
+    expect(callback).toHaveBeenCalledWith(3)
+  })
+
+  test('immediately invokes onDone if the action already closed', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.resolve(true)
+    action.onDone(callback)
+
+    expect(callback).toHaveBeenCalledWith(true)
+  })
+
+  test('actions are no longer open when they complete', function () {
+    const action = new Action(identity)
+
+    action.open(true)
+    action.send(true)
+    action.resolve(true)
+
+    expect(action.is('loading')).toBe(false)
+    expect(action.is('done')).toBe(true)
+  })
+
+  test('actions can not be resolved after rejected', function () {
+    const action = new Action(identity)
+
+    action.reject()
+    action.resolve()
+
+    expect(action.is('error')).toBe(true)
+    expect(action.is('done')).toBe(false)
+  })
+
+})
+
+describe('rejected state', function () {
+
+  test('exposes a error type when rejected', function () {
+    const action = new Action(identity)
+
+    action.reject()
+
+    expect(action.type).toBe(identity.error)
+  })
+
+  test('triggers a error event when it is rejected', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.once('error', callback)
+    action.reject(404)
+
+    expect(callback).toHaveBeenCalledWith(404)
+  })
+
+  test('listens to failures', function () {
+    const action = new Action(identity)
+    const fn = jest.fn()
+
+    action.onError(fn)
+    action.reject(true)
+
+    expect(fn).toHaveBeenCalledWith(true)
+  })
+
+  test('immediately invokes onError if the action already failed', function () {
+    const action = new Action(identity)
+    const fn = jest.fn()
+
+    action.reject(true)
+    action.onError(fn)
+
+    expect(fn).toHaveBeenCalledWith(true)
+  })
+
+})
+
+describe('disposed state', function () {
+
+  test('actions are disposable when they resolve', function () {
+    const action = new Action(identity)
+
+    action.resolve(true)
+
+    expect(action.is('disposable')).toBe(true)
+  })
+
+  test('actions are disposable when they cancel', function () {
+    const action = new Action(identity)
+
+    action.cancel(true)
+
+    expect(action.is('disposable')).toBe(true)
+  })
+
+  test('actions are disposable when they fail', function () {
+    const action = new Action(identity)
+
+    action.reject(true)
+
+    expect(action.is('disposable')).toBe(true)
+  })
+
+  test('will not change states if already disposed', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.cancel()
+    action.resolve()
+
+    expect(action.is('cancelled')).toBe(true)
+    expect(action.is('resolved')).toBe(false)
+  })
+
+})
+
+describe('cancelled state', function () {
+
+  test('triggers a cancel event when it is cancelled', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.once('cancel', callback)
+    action.cancel()
+
+    expect(callback).toHaveBeenCalled()
+  })
+
+  test('becomes disposable when cancelled', function () {
+    const action = new Action(identity)
+
+    action.cancel()
+
+    expect(action.is('disposable')).toBe(true)
+  })
+
+  test('exposes a cancelled type when cancelled', function () {
+    const action = new Action(identity)
+
+    action.cancel()
+
+    expect(action.type).toBe(identity.cancelled)
+  })
+
+  test('onCancel is a one time binding', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.onCancel(callback)
+
+    action.cancel()
+    action.cancel()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  test('executes onCancel if the action is already cancelled', function () {
+    const action = new Action(identity)
+    const callback = jest.fn()
+
+    action.cancel()
+    action.onCancel(callback)
+
+    expect(callback).toHaveBeenCalled()
+  })
+
+})
+
+describe('promise interop', function () {
+
+  test('actions interop with promises', function () {
+    const action = new Action(identity)
+
+    action.resolve('Test')
+
+    return action.then(result => expect(result).toBe('Test'))
+  })
+
+  test('actions interop with async/await', async function () {
+    const action = new Action(identity)
+
+    action.resolve('Test')
+
+    const payload = await action
+
+    expect(payload).toBe('Test')
+  })
+
 })

--- a/test/microcosm.test.js
+++ b/test/microcosm.test.js
@@ -1,22 +1,5 @@
 import Microcosm from '../src/microcosm'
 
-test('patch partially updates', function () {
-  const repo = new Microcosm()
-
-  repo.addDomain('a', {
-    getInitialState: n => true
-  })
-
-  repo.addDomain('b', {
-    getInitialState: n => true
-  })
-
-  repo.patch({ a: false })
-
-  expect(repo.state.a).toBe(false)
-  expect(repo.state.b).toBe(true)
-})
-
 test('it will not deserialize null', function () {
   const repo = new Microcosm()
 
@@ -114,4 +97,84 @@ test('if pure, it will emit a change if state is not shallowly equal', function 
   repo.push(identity, 1)
 
   expect(repo.state).not.toEqual(first)
+})
+
+describe('patch', function () {
+
+  test('patch partially updates state', function () {
+    const repo = new Microcosm()
+
+    repo.addDomain('a', {
+      getInitialState: n => true
+    })
+
+    repo.addDomain('b', {
+      getInitialState: n => true
+    })
+
+    repo.patch({ a: false })
+
+    expect(repo.state.a).toBe(false)
+    expect(repo.state.b).toBe(true)
+  })
+
+  test('patch can deserialize the provided data', function () {
+    const repo = new Microcosm()
+
+    repo.addDomain('test', {
+      getInitialState: n => '',
+      deserialize: n => n.toUpperCase()
+    })
+
+    repo.patch({ test: 'deserialize' }, true)
+
+    expect(repo.state.test).toBe('DESERIALIZE')
+  })
+
+})
+
+describe('reset', function () {
+
+  test('reverts to the initial state', function () {
+    const repo = new Microcosm()
+
+    repo.addDomain('test', {
+      getInitialState: n => true
+    })
+
+    repo.patch({ test: false })
+
+    expect(repo.state.test).toBe(false)
+
+    repo.reset()
+
+    expect(repo.state.test).toBe(true)
+  })
+
+  test('can fold in a data parameter', function () {
+    const repo = new Microcosm()
+
+    repo.addDomain('first', {
+      getInitialState: n => true
+    })
+
+    repo.reset({ second: true })
+
+    expect(repo.state.first).toBe(true)
+    expect(repo.state.second).toBe(true)
+  })
+
+  test('can deserialized the data parameter', function () {
+    const repo = new Microcosm()
+
+    repo.addDomain('test', {
+      getInitialState: n => '',
+      deserialize: n => n.toUpperCase()
+    })
+
+    repo.reset({ test: 'deserialize' }, true)
+
+    expect(repo.state.test).toBe('DESERIALIZE')
+  })
+
 })


### PR DESCRIPTION
When the second argument of `Microcosm::patch` or `Microcosm::reset` is
true, Microcosm will call `deserialize on the provided data payload.

```javascript
repo.reset({ users: [{ id: 'bob' ] }, true) // will deserialize
repo.patch({ users: [{ id: 'bob' ] }, true) // will deserialize
```

Fix #158