### PR TITLE
Subscribe to repo on mount

### DIFF
--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -506,6 +506,7 @@ test('setup is called before the initial model', function () {
 
   mount(<Test />)
 
-  expect(spy).toHaveBeenCalledTimes(2)
-  expect(spy).lastCalledWith('model')
+  let sequence = spy.mock.calls.map(args => args[0])
+
+  expect(sequence).toEqual(['setup', 'model'])
 })


### PR DESCRIPTION
https://twitter.com/dan_abramov/status/790581793397305345:

> Don’t subscribe to data sources in constructor or componentWillMount(). Use componentDidMount(), teardown in componentWillUnmount().

So we don't, anymore. I've also removed `this.pure` in favor of `this.isImpure()`.