### PR TITLE
Rework one-time event subscription

### DIFF
--- a/test/emitter.test.js
+++ b/test/emitter.test.js
@@ -19,18 +19,18 @@ test('adds listeners', function () {
   expect(calls).toEqual([ 'one', 1, 'two', 1, 'one', 2, 'two', 2 ])
 })
 
-test('adds a single-shot listener', function (done) {
+test('adds a single-shot listener', function () {
   const emitter = new Emitter
+  const callback = jest.fn()
 
-  emitter.once('foo', function (val) {
-    expect(val).toBe(1)
-    done()
-  })
+  emitter.once('foo', callback)
 
   emitter._emit('foo', 1)
   emitter._emit('foo', 2)
   emitter._emit('foo', 3)
   emitter._emit('bar', 1)
+
+  expect(callback).toHaveBeenCalledTimes(1)
 })
 
 test('should remove a listener', function () {


### PR DESCRIPTION
Before this commit, one time event subscription followed a different
pattern than regular event subscription. This lead to extra conditions
in code. This commit reworks subscriptions to allow a third argument:
the number of times the subscription should emit.

By default, this is Infinity.