### PR TITLE
Make send directly available to Presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.4.0
+
+- Expose `send` within a presenter. Presenters can now broadcast intents
+
 ## 10.3.6
 
 - Properly deploy documentation with build (hopefully this should sort out

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcosm",
-  "version": "10.3.6",
+  "version": "10.4.0-alpha",
   "private": true,
   "description": "Flux with first-class actions and state sandboxing.",
   "main": "src/microcosm.js",

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -19,6 +19,54 @@ function wrappedRender () {
  */
 class Presenter extends React.Component {
 
+  static contextTypes = {
+    send : React.PropTypes.func
+  }
+
+  static childContextTypes = {
+    send : React.PropTypes.func
+  }
+
+  getChildContext () {
+    return {
+      send : this.send.bind(this)
+    }
+  }
+
+  /**
+   * Provides a way for views to send messages back to the presenter
+   * in a way that does not require passing callbacks down through the
+   * view. This method is exposed by the Presenter via the React context
+   * API.
+   *
+   * Send bubbles. If the closest presenter does not implement the intent,
+   * it will check it's parent presenter. This repeats until there is no parent,
+   * in which case it throws an error.
+   *
+   * @param {string} intent - The name of a method the view wishes to invoke
+   * @param {...any} params - Arguments to invoke the named method with
+   */
+  send (intent, ...params) {
+    const registry = this.register()
+
+    // Tag intents so that they register the same way in the Presenter
+    // and Microcosm instance
+    intent = tag(intent)
+
+    // Does the presenter register to this intent?
+    if (registry && registry.hasOwnProperty(intent)) {
+      return registry[intent].apply(this, [ this.repo, ...params ])
+    }
+
+    // No: try the parent presenter
+    if (this.context.send) {
+      return this.context.send(intent, ...params)
+    }
+
+    // If we hit the top, push the intent into the Microcosm instance
+    return this.repo.push(intent, ...params)
+  }
+
   constructor(props, context) {
     super(props, context)
 
@@ -128,13 +176,11 @@ class PresenterContext extends React.Component {
   }
 
   static contextTypes = {
-    repo : React.PropTypes.object,
-    send : React.PropTypes.func
+    repo : React.PropTypes.object
   }
 
   static childContextTypes = {
-    repo : React.PropTypes.object,
-    send : React.PropTypes.func
+    repo : React.PropTypes.object
   }
 
   constructor (props, context) {
@@ -145,8 +191,7 @@ class PresenterContext extends React.Component {
 
   getChildContext () {
     return {
-      repo : this.repo,
-      send : this.send.bind(this)
+      repo : this.repo
     }
   }
 
@@ -231,41 +276,6 @@ class PresenterContext extends React.Component {
 
     return nextState
   }
-
-  /**
-   * Provides a way for views to send messages back to the presenter
-   * in a way that does not require passing callbacks down through the
-   * view. This method is exposed by the Presenter via the React context
-   * API.
-   *
-   * Send bubbles. If the closest presenter does not implement the intent,
-   * it will check it's parent presenter. This repeats until there is no parent,
-   * in which case it throws an error.
-   *
-   * @param {string} intent - The name of a method the view wishes to invoke
-   * @param {...any} params - Arguments to invoke the named method with
-   */
-  send (intent, ...params) {
-    const registry = this.props.presenter.register()
-
-    // Tag intents so that they register the same way in the Presenter
-    // and Microcosm instance
-    intent = tag(intent)
-
-    // Does the presenter register to this intent?
-    if (registry && registry.hasOwnProperty(intent)) {
-      return registry[intent].apply(this.props.presenter, [ this.repo, ...params ])
-    }
-
-    // No: try the parent presenter
-    if (this.context.send) {
-      return this.context.send(intent, ...params)
-    }
-
-    // If we hit the top, push the intent into the Microcosm instance
-    return this.repo.push(intent, ...params)
-  }
-
 }
 
 

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -563,6 +563,23 @@ describe('intents', function() {
     expect(spy).not.toHaveBeenCalled()
   })
 
+  test('send is available in setup', function () {
+    const test = jest.fn()
+
+    class Parent extends Presenter {
+      setup() {
+        this.send('test')
+      }
+      register() {
+        return { test }
+      }
+    }
+
+    mount(<Parent />)
+
+    expect(test).toHaveBeenCalled()
+  })
+
   test('send can be called directly from the Presenter', function () {
     const test = jest.fn()
 

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -563,22 +563,18 @@ describe('intents', function() {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  test('send can be called directly from the Presenter', function (done) {
+  test('send can be called directly from the Presenter', function () {
     const test = jest.fn()
 
     class Parent extends Presenter {
-      setup(repo) {
-        this.send('test')
-      }
       register() {
-        return { test: (repo, props) => done() }
-      }
-      view () {
-        return <div />
+        return { test }
       }
     }
 
-    mount(<Parent repo={ new Microcosm() } />).find(View).simulate('click')
+    mount(<Parent />).instance().send('test', true)
+
+    expect(test).toHaveBeenCalled()
   })
 
 })

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -563,4 +563,22 @@ describe('intents', function() {
     expect(spy).not.toHaveBeenCalled()
   })
 
+  test('send can be called directly from the Presenter', function (done) {
+    const test = jest.fn()
+
+    class Parent extends Presenter {
+      setup(repo) {
+        this.send('test')
+      }
+      register() {
+        return { test: (repo, props) => done() }
+      }
+      view () {
+        return <div />
+      }
+    }
+
+    mount(<Parent repo={ new Microcosm() } />).find(View).simulate('click')
+  })
+
 })


### PR DESCRIPTION
This allows the method to be accessed from the `Presenter` directly.

Basically so we can do pass the `send` method from a presenter to other classes or functions in the setup method: 

```js
class MySocketyPresenter extends Presenter {
  setup(repo) {
     this.sockets = {
        chat: new IntentSocket(`graph/${id}/chat`, this.send), 
        graph: new IntentSocket(`graph/${id}/graph`, this.send)
      }
  }
}
```