### PR TITLE
Patching on child repos should not effect parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 10.8.0-alpha4
+
+- `patch` and `reset` only apply to the repo that invoked them (and thus their
+  children)
+
 ## 10.8.0-alpha3
 
 - Throw an error if Presenter::view is nully. This will inevitably

--- a/src/domains/meta.js
+++ b/src/domains/meta.js
@@ -7,14 +7,27 @@
 import lifecycle from '../lifecycle'
 import merge from '../merge'
 
-export default {
+class MetaDomain {
 
-  [lifecycle._willReset](_old, next) {
-    return next
-  },
+  setup (repo) {
+    this.repo = repo
+  }
 
-  [lifecycle._willPatch](old, next) {
-    return merge({}, old, next)
+  reset (state, { owner, data }) {
+    return owner === this.repo ? data : state
+  }
+
+  patch (state, { owner, data }) {
+    return owner === this.repo ? merge({}, state, data) : state
+  }
+
+  register() {
+    return {
+      [lifecycle._willReset]: this.reset,
+      [lifecycle._willPatch]: this.patch
+    }
   }
 
 }
+
+export default MetaDomain

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -53,10 +53,8 @@ export default class Microcosm extends Emitter {
     // is shallowly different (or always, if impure).
     this.state = parent ? parent.state : {}
 
-    // Only the root gets the meta domain
-    if (!parent) {
-      this.addDomain(MetaDomain)
-    }
+    // Setup a domain to handle patch and reset actions
+    this.addDomain(MetaDomain)
 
     // Microcosm is now ready. Call the setup lifecycle method
     this.setup()
@@ -312,7 +310,10 @@ export default class Microcosm extends Emitter {
       data = this.deserialize(data)
     }
 
-    return this.push(lifecycle._willReset, merge(this.getInitialState(), data))
+    return this.push(lifecycle._willReset, {
+      owner : this,
+      data  : merge(this.getInitialState(), data)
+    })
   }
 
   /**
@@ -328,7 +329,10 @@ export default class Microcosm extends Emitter {
       data = this.deserialize(data)
     }
 
-    return this.push(lifecycle._willPatch, data)
+    return this.push(lifecycle._willPatch, {
+      owner : this,
+      data  : data
+    })
   }
 
   replace (state) {

--- a/test/fork.test.js
+++ b/test/fork.test.js
@@ -280,3 +280,57 @@ test('forks properly archive after a patch', () => {
   expect(child.state.one).toBe(true)
   expect(child.state.two).toBe(true)
 })
+
+test('patch does not cause forks to revert state', function () {
+  const parent = new Microcosm()
+  const child = parent.fork()
+
+  child.addDomain('count', {
+    register () {
+      return {
+        'add' : (a, b) => a + b
+      }
+    }
+  })
+
+  child.patch({ count: 2 })
+
+  child.push('add', 1)
+  child.push('add', 1)
+
+  // Forks inherit state. If a parent repo's state contains a key, it will
+  // pass the associated value down to a child. This allows state to flow
+  // downward through the repo network.
+  //
+  // Unfortunately, this causes an unexpected behavior with `patch` where
+  // consecutive actions always operate on the original patched value, and not
+  // the new state produced by a child.
+  expect(child.state.count).toEqual(4)
+})
+
+test('reset does not cause forks to revert state', function () {
+  const parent = new Microcosm()
+  const child = parent.fork()
+
+  child.addDomain('count', {
+    register () {
+      return {
+        'add' : (a, b) => a + b
+      }
+    }
+  })
+
+  child.reset({ count: 2 })
+
+  child.push('add', 1)
+  child.push('add', 1)
+
+  // Forks inherit state. If a parent repo's state contains a key, it will
+  // pass the associated value down to a child. This allows state to flow
+  // downward through the repo network.
+  //
+  // Unfortunately, this causes an unexpected behavior with `patch` where
+  // consecutive actions always operate on the original patched value, and not
+  // the new state produced by a child.
+  expect(child.state.count).toEqual(4)
+})


### PR DESCRIPTION
Forks inherit state. If a parent repo's state contains a key, it will
pass the associated value down to a child. This allows state to flow
downward through the repo network.

Unfortunately, this causes an unexpected behavior with `patch` where
consecutive actions always operate on the original patched value, and
not the new state produced by a child.