### PR TITLE
Add concept of sub-domains

### DIFF
--- a/docs/api/domains.md
+++ b/docs/api/domains.md
@@ -192,18 +192,18 @@ sub-domains for themselves.
 ```javascript
 import Domain from 'microcosm/domain'
 
-class Node {
+class Nodes {
   getInitialState() { return [] }
 }
 
-class Edge {
+class Edges {
   getInitialState() { return [] }
 }
 
 class Network extends Domain {
   setup () {
-    this.addDomain('nodes', Node)
-    this.addDomain('edges', Edge)
+    this.addDomain('nodes', Nodes)
+    this.addDomain('edges', Edges)
   }
 }
 

--- a/docs/api/domains.md
+++ b/docs/api/domains.md
@@ -201,7 +201,7 @@ class Edge {
 }
 
 class Network extends Domain {
-  setup (repo) {
+  setup () {
     this.addDomain('nodes', Node)
     this.addDomain('edges', Edge)
   }

--- a/docs/api/domains.md
+++ b/docs/api/domains.md
@@ -178,3 +178,37 @@ const Planets = {
   }
 }
 ```
+
+### `addDomain(key, config)`
+
+Add a sub-domain that lives under the key of the parent domain. Sub-domains:
+
+1. Resolve actions after the parent
+2. Operate on a nested key
+
+In all other ways, they are identical to regular domains, and can have
+sub-domains for themselves.
+
+```javascript
+class Node {
+  getInitialState() { return [] }
+}
+
+class Edge {
+  getInitialState() { return [] }
+}
+
+class Network {
+  setup (repo) {
+    this.addDomain('nodes', Node)
+    this.addDomain('edges', Edge)
+  }
+}
+
+const repo = new Microcosm()
+
+repo.addDomain('network', Network)
+
+console.log(repo.state.network.edges) // []
+console.log(repo.state.network.nodes) // []
+```

--- a/docs/api/domains.md
+++ b/docs/api/domains.md
@@ -190,6 +190,8 @@ In all other ways, they are identical to regular domains, and can have
 sub-domains for themselves.
 
 ```javascript
+import Domain from 'microcosm/domain'
+
 class Node {
   getInitialState() { return [] }
 }
@@ -198,7 +200,7 @@ class Edge {
   getInitialState() { return [] }
 }
 
-class Network {
+class Network extends Domain {
   setup (repo) {
     this.addDomain('nodes', Node)
     this.addDomain('edges', Edge)

--- a/src/domain.js
+++ b/src/domain.js
@@ -98,14 +98,6 @@ export default class Domain {
    * Microcosms?
    */
    addDomain (key, config) {
-     if (arguments.length < 2) {
-       // Important! Assignment this way is important
-       // to support IE9, which has an odd way of referencing
-       // arguments
-       config = key
-       key = []
-     }
-
      this._realm.add([this._key].concat(key), config)
 
      return this

--- a/src/domain.js
+++ b/src/domain.js
@@ -90,4 +90,25 @@ export default class Domain {
     return next
   }
 
+
+  /**
+   * Add a sub-domain. This domain will be relative to the parent
+   *
+   * TODO: Could there be a time in the future when Domains are just
+   * Microcosms?
+   */
+   addDomain (key, config) {
+     if (arguments.length < 2) {
+       // Important! Assignment this way is important
+       // to support IE9, which has an odd way of referencing
+       // arguments
+       config = key
+       key = []
+     }
+
+     this._realm.add([this._key].concat(key), config)
+
+     return this
+   }
+
 }

--- a/src/getDomainHandlers.js
+++ b/src/getDomainHandlers.js
@@ -15,9 +15,12 @@ function getHandler (key, domain, type) {
     const registrations = domain.register(type)
 
     if (process.env.NODE_ENV !== 'production') {
-      if (registrations.hasOwnProperty(type) && registrations[type] === undefined) {
-        console.warn('A domain handler for "%s" registered an undefined handler for `%s`. ' +
-                     'Check the register method for this domain.', key, format(type))
+      if (registrations.hasOwnProperty(type) && typeof registrations[type] !== 'function') {
+        console.warn('Unable to register `%s` at domain path `["%s"]`. Handlers ' +
+                     'must be functions, instead got `%s`. Check the register ' +
+                     'method for this domain.',
+                     format(type), key.join('", "'), typeof registrations[type])
+        return null
       }
     }
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -266,7 +266,7 @@ export default class Microcosm extends Emitter {
    * @return {Microcosm} self
    */
   addDomain () {
-    this.realm.add.apply(this.realm, arguments)
+    this.realm.add(...arguments)
 
     return this.rebase()
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -28,7 +28,7 @@ export default class Realm {
       // to support IE9, which has an odd way of referencing
       // arguments
       config = key
-      key = null
+      key = []
     }
 
     let domain = null
@@ -39,11 +39,15 @@ export default class Realm {
       domain = merge({}, config)
     }
 
+    // Assign the domain to a given realm and key to allow for nesting
+    domain._key   = [].concat(key)
+    domain._realm = this
+
     // Allow for simple classes and object primitives. Make sure
     // they implement the key Domain methods.
     Domain.ensure(domain)
 
-    this.domains[this.domains.length] = [ key, domain ]
+    this.domains[this.domains.length] = [ domain._key, domain ]
 
     // Reset the registry
     this.registry = {}

--- a/src/update.js
+++ b/src/update.js
@@ -1,42 +1,50 @@
 /**
- * Retrieve a value from an object. If no key is provided, just
- * return the object.
- *
- * @example
- *     get({ foo: 'bar' }, 'foo') // 'bar'
- *     get({ foo: 'bar' }, undefined) // { foo: 'bar' }
- *
- * @param {Object} object - The target object
- * @param {String} key - The key to access
- * @return {Any} A retrieved value
+ * Non-destructive data operations
+ * Taken from Sprout:
+ * https://github.com/herrstucki/sprout/blob/master/src/util.js
  */
-function get (object, key) {
-  return key == null ? object : object[key]
+
+import merge from './merge'
+
+function get (target, keys) {
+  if (keys == null) {
+    return target
+  }
+
+  if (Array.isArray(keys) === false) {
+    if (target && keys) {
+      return target[keys]
+    }
+  }
+
+  for (var i = 0; target && i < keys.length; i++) {
+    target = target[keys[i]]
+  }
+
+  return target
 }
 
-/**
- * Immutabily assign a value to a provided object at a given key. If
- * the value is the same, don't do anything. Otherwise return a new
- * object.
- *
- * @example
- *     set({ foo: 'bar' }, 'baz', 'bip') // { foo: 'bar', baz: 'bip' }
- *
- * @param {Object} object - The target object
- * @param {String} key - The key to set
- * @param {Any} value - The value to assign
- * @return {Any} A copy of the object with the new assignment.
- */
-function set (object, key, value) {
-  // If the key path is null, there's no need to traverse the
-  // object. Just return the value.
-  if (key == null) {
+function set (target, keys, value) {
+  if (keys === null) {
     return value
   }
 
-  object[key] = value
+  if (Array.isArray(keys) === false) {
+    if (target && keys) {
+      return merge({}, target, { [keys]: value })
+    }
+  }
 
-  return object
+  if (keys.length) {
+    let head  = keys[0]
+    let clone = merge({}, target)
+
+    clone[head] = keys.length > 1 ? set(clone[head] || {}, keys.slice(1), value) : value
+
+    return clone
+  } else {
+    return value
+  }
 }
 
 export default { get, set }

--- a/src/update.js
+++ b/src/update.js
@@ -17,7 +17,7 @@ function get (target, keys) {
     }
   }
 
-  for (var i = 0; target && i < keys.length; i++) {
+  for (var i = 0, len = keys.length; target && i < len; i++) {
     target = target[keys[i]]
   }
 

--- a/src/update.js
+++ b/src/update.js
@@ -7,16 +7,6 @@
 import merge from './merge'
 
 function get (target, keys) {
-  if (keys == null) {
-    return target
-  }
-
-  if (Array.isArray(keys) === false) {
-    if (target && keys) {
-      return target[keys]
-    }
-  }
-
   for (var i = 0, len = keys.length; target && i < len; i++) {
     target = target[keys[i]]
   }
@@ -25,16 +15,6 @@ function get (target, keys) {
 }
 
 function set (target, keys, value) {
-  if (keys === null) {
-    return value
-  }
-
-  if (Array.isArray(keys) === false) {
-    if (target && keys) {
-      return merge({}, target, { [keys]: value })
-    }
-  }
-
   if (keys.length) {
     let head  = keys[0]
     let clone = merge({}, target)

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -69,7 +69,6 @@ describe('::commit', function() {
 
 })
 
-
 describe('Creation modes', function () {
 
   test('object - primitive', function () {
@@ -187,4 +186,66 @@ describe('Action registration', function() {
     logger.restore()
   })
 
+})
+
+describe('Sub-domains', function () {
+
+  test('a domain can add nested child domains within its setup method', function () {
+    class Node {
+      getInitialState() { return [] }
+    }
+
+    class Edge {
+      getInitialState() { return [] }
+    }
+
+    class Network {
+      setup (repo) {
+        this.addDomain('nodes', Node)
+        this.addDomain('edges', Edge)
+      }
+    }
+
+    const repo = new Microcosm()
+
+    repo.addDomain('network', Network)
+
+    expect(repo.state.network.edges).toEqual([])
+    expect(repo.state.network.nodes).toEqual([])
+  })
+
+  test('sub-domains respond to actions after their parents', function () {
+    let action = n => n
+
+    class Node {
+      getInitialState() {
+        return []
+      }
+
+      register () {
+        return {
+          [action] : () => true
+        }
+      }
+    }
+
+    class Network {
+      setup (repo) {
+        this.addDomain('nodes', Node)
+      }
+      register () {
+        return {
+          [action] : (a, b) => ({ ...a, parent: true })
+        }
+      }
+    }
+
+    const repo = new Microcosm()
+
+    repo.addDomain('network', Network)
+    repo.push(action)
+
+    expect(repo.state.network.parent).toEqual(true)
+    expect(repo.state.network.nodes).toEqual(true)
+  })
 })


### PR DESCRIPTION
I want to slowly move towards Domains just being Microcosms mounted at paths to other Microcosms:

```javascript
import Domain from 'microcosm/domain'

class Node {
  getInitialState() { return [] }
}

class Edge {
  getInitialState() { return [] }
}

class Network extends Domain {
  setup () {
    this.addDomain('nodes', Nodes)
    this.addDomain('edges', Edges)
  }
}

const repo = new Microcosm()

repo.addDomain('network', Network)

expect(repo.state.network.edges).toEqual([])
expect(repo.state.network.nodes).toEqual([])
```

I also updated error messages to correctly encounter non-function keys (and respond with null):

```
Unable to register `action.done` at domain path `["network", "nodes"]`. Handlers must be
functions, instead got `undefined`. Check the register method for this domain.
```