### PR TITLE
Warn when withIntent is called as function

### DIFF
--- a/src/addons/with-intent.js
+++ b/src/addons/with-intent.js
@@ -5,10 +5,30 @@
 import React from 'react'
 import merge from '../merge'
 
+const danger = function (intent, params) {
+  console.error('Unable to broadcast "%s" with parameters `%s`. withIntent did not receive context.',
+                intent, JSON.stringify(params))
+}
+
+const displayName = function (Component) {
+  if (typeof Component === 'function') {
+    return Component.name
+  }
+
+  return Component.constructor.name || Component.displayName
+}
+
 export default function withIntent (Component, intent) {
 
   function WithIntent (props, context) {
-    let send = props.send || context.send
+    let send = danger
+
+    if (context) {
+      send = props.send || context.send
+    } else {
+      console.error('withIntent(%s) did not receive context, was it called as a function instead of with React.createElement?',
+                    displayName(Component))
+    }
 
     return React.createElement(Component, merge({ send }, props))
   }

--- a/src/addons/with-intent.js
+++ b/src/addons/with-intent.js
@@ -4,18 +4,11 @@
 
 import React from 'react'
 import merge from '../merge'
+import displayName from '../display-name'
 
 const danger = function (intent, params) {
   console.error('Unable to broadcast "%s" with parameters `%s`. withIntent did not receive context.',
                 intent, JSON.stringify(params))
-}
-
-const displayName = function (Component) {
-  if (typeof Component === 'function') {
-    return Component.name
-  }
-
-  return Component.constructor.name || Component.displayName
 }
 
 export default function withIntent (Component, intent) {

--- a/src/display-name.js
+++ b/src/display-name.js
@@ -1,0 +1,4 @@
+// Thanks: https://github.com/jurassix/react-display-name
+export default function (Component) {
+  return Component.displayName || Component.name || 'Component'
+}

--- a/test/addons/withIntent.test.js
+++ b/test/addons/withIntent.test.js
@@ -74,19 +74,4 @@ describe('When there is no context (called directly as a function)', function ()
     expect(logger.last('error')).toContain('withIntent(Button)')
   })
 
-  test('uses the component name in the debug message for class components', function () {
-    const Button = withIntent(class Button extends React.PureComponent {
-      render () {
-        var { send } = this.props
-        return (
-          <button type="button" onClick={() => send('intent')}>Click me</button>
-        )
-      }
-    })
-
-    Button()
-
-    expect(logger.last('error')).toContain('withIntent(Button)')
-  })
-
 })

--- a/test/addons/withIntent.test.js
+++ b/test/addons/withIntent.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import withIntent from '../../src/addons/with-intent'
+import logger from '../helpers/logger'
 import {mount} from 'enzyme'
 
 test('extracts send from context', function () {
@@ -37,4 +38,55 @@ test('allows send to be overridden by a prop', function () {
   mount(<Button send={send}/>).simulate('click')
 
   expect(send).toHaveBeenCalledWith('intent')
+})
+
+describe('When there is no context (called directly as a function)', function () {
+
+  beforeEach(function () {
+    logger.record()
+  })
+
+  afterEach(function() {
+    logger.restore()
+  })
+
+  test('safely degrades to an error reporting message', function () {
+    const Button = withIntent(function Button ({ send }) {
+      return (
+        <button type="button" onClick={() => send('intent', true)}>Click me</button>
+      )
+    })
+
+    let component = mount(Button()).simulate('click')
+
+    expect(logger.last('error')).toContain('Unable to broadcast "intent" with parameters `true`.')
+  })
+
+  test('uses the component name in the debug message for stateless components', function () {
+    const Button = withIntent(function Button ({ send }) {
+      return (
+        <button type="button" onClick={() => send('intent')}>Click me</button>
+      )
+    })
+
+    Button()
+
+    expect(logger.last('error')).toContain('withIntent(Button)')
+  })
+
+  test('uses the component name in the debug message for class components', function () {
+    const Button = withIntent(class Button extends React.PureComponent {
+      render () {
+        var { send } = this.props
+        return (
+          <button type="button" onClick={() => send('intent')}>Click me</button>
+        )
+      }
+    })
+
+    Button()
+
+    expect(logger.last('error')).toContain('withIntent(Button)')
+  })
+
 })

--- a/test/display-name.test.js
+++ b/test/display-name.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import displayName from '../src/display-name'
+
+test('gets a stateless component name', function () {
+  const name = displayName(function Button () {})
+
+  expect(name).toBe('Button')
+})
+
+test('gets a class component name', function () {
+  const name = displayName(class Button extends React.PureComponent {})
+
+  expect(name).toBe('Button')
+})
+
+test('gets a createClass component name', function () {
+  const Button = React.createClass({
+    render () {
+      var { send } = this.props
+      return (
+        <button type="button" onClick={() => send('intent')}>Click me</button>
+      )
+    }
+  })
+
+  const name = displayName(Button)
+
+  expect(name).toBe('Button')
+})
+
+test('uses "Component" when there is no name', function () {
+  expect(displayName(React.createClass({ render () {} }))).toBe('Component')
+})

--- a/test/helpers/logger.js
+++ b/test/helpers/logger.js
@@ -2,6 +2,8 @@
  * In order to test warnings, record console output.
  */
 
+const util = require('util')
+
 const originals = {}
 const messages = {
   log: [],
@@ -14,12 +16,12 @@ export default {
   record() {
     for (let key in messages) {
       originals[key] = console[key]
-      console[key] = (...args) => messages[key].push([args.join(' ')])
+      console[key] = (...args) => messages[key].push(args)
     }
   },
 
   last(key) {
-    return messages[key][messages[key].length - 1]
+    return util.format.apply(util, messages[key].concat().pop())
   },
 
   count(key) {


### PR DESCRIPTION
I just hit an issue where calling `withIntent` returns a stateless (function) component and the Presenter thought it was a plain old `view()` method. That meant that `withIntent` never received proper context 😢.

## Changes

**withIntent displays a few nice warnings now:**

<img width="808" alt="screen shot 2016-12-05 at 8 59 40 am" src="https://cloud.githubusercontent.com/assets/590904/20887630/781f1e38-bac9-11e6-8fca-807805406376.png">

**Presenters always call `React.createElement` on their view**.

This means that the new signature for a view method is:

```javascript
view (model, context) {
  return <Component />
}
```

Generally, I would like to move away from using `view` as a method and always assign it as an inline property or getter. Having a `view` method that returns JSX has been a source of confusion when I solicit feedback about the abstraction.

---

## Questions

1. Should we raise an exception instead of gracefully failing? 
2. Is the Presenter tweak (calling `createElement`) a breaking change? 
