### PR TITLE
Allow custom repo behavior in Presenter

### DIFF
--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -276,3 +276,13 @@ class HelloWorldPresenter extends Presenter {
   }
 }
 ```
+
+### getRepo(repo, props)
+
+Runs before assigning a repo to a Presenter. This method is given the
+parent repo, either passed in via `props` or `context`. By default, it
+returns a fork of that repo, or a new Microcosm if no repo is
+provided.
+
+This provides an opportunity to customize the repo behavior for a
+particular Presenter.

--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -285,4 +285,13 @@ returns a fork of that repo, or a new Microcosm if no repo is
 provided.
 
 This provides an opportunity to customize the repo behavior for a
-particular Presenter.
+particular Presenter. For example, to circumvent the default Presenter
+forking behavior:
+
+```javascript
+class NoFork extends Presenter {
+  getRepo (repo) {
+    return repo
+  }
+}
+```

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -27,6 +27,10 @@ function Presenter (props, context) {
 inherit(Presenter, BaseComponent, {
   constructor: Presenter,
 
+  getRepo (repo, props) {
+    return repo ? repo.fork() : new Microcosm()
+  },
+
   _setRepo (repo) {
     this.repo = repo
 
@@ -152,9 +156,9 @@ inherit(PresenterContext, BaseComponent, {
   },
 
   getRepo () {
-    const repo = this.props.repo || this.context.repo
+    const { presenter, parentProps, repo } = this.props
 
-    return repo ? repo.fork() : new Microcosm()
+    return presenter.getRepo(repo || this.context.repo, parentProps)
   },
 
   updatePropMap ({ presenter, parentProps, parentState }) {

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -521,6 +521,23 @@ describe('::render', function () {
 
 })
 
+describe('::getRepo', function () {
+
+  it('can circumvent forking behavior', function () {
+    class NoFork extends Presenter {
+      getRepo (repo) {
+        return repo
+      }
+    }
+
+    let repo = new Microcosm()
+    let wrapper = mount(<NoFork repo={repo} />)
+
+    expect(wrapper.instance().repo).toEqual(repo)
+  })
+
+})
+
 describe('intents', function() {
 
   test('receives intent events', function () {


### PR DESCRIPTION
This commit adds an extendable getRepo method to the Presenter
prototype that allows custom repo assignment behavior. For example, if
we wanted to avoid the default forking behavior:

```javascript
class NoFork extends Presenter {
  getRepo (repo) {
    return repo
  }
}
```