### PR TITLE
Payload definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 11.1.0
+
+- Added getRepo method to presenters to allow greater control over
+  repo assignment
+- Actions may now, intentionally, be set to undefined
+
 ## 11.0.0
 
 - Fix bug where Presenter given stateless view component as an inline

--- a/src/action.js
+++ b/src/action.js
@@ -61,7 +61,7 @@ inherit(Action, Emitter, {
     this.type = this.behavior[type]
     this.disposable = DISPOSABLE.hasOwnProperty(type)
 
-    if (payload !== undefined) {
+    if (arguments.length > 1) {
       this.payload = payload
     }
 
@@ -74,8 +74,8 @@ inherit(Action, Emitter, {
    * Set the action state to "open", then set a payload if provided. Triggers
    * the "open" event.
    */
-  open (payload) {
-    if (this.set('open', payload)) {
+  open (...params) {
+    if (this.set('open', ...params)) {
       this._emit('open', this.payload)
     }
 
@@ -86,8 +86,8 @@ inherit(Action, Emitter, {
    * Set the action state to "loading", then set a payload if provided.
    * Triggers the "update" event.
    */
-  send (payload) {
-    if (this.set('loading', payload)) {
+  send (...params) {
+    if (this.set('loading', ...params)) {
       this._emit('update', this.payload)
     }
 
@@ -98,8 +98,8 @@ inherit(Action, Emitter, {
    * Set the action state to "error" and marks the action for clean up, then
    * set a payload if provided. Triggers the "error" event.
    */
-  reject (payload) {
-    if (this.set('error', payload)) {
+  reject (...params) {
+    if (this.set('error', ...params)) {
       this._emit('error', this.payload)
     }
 
@@ -110,8 +110,8 @@ inherit(Action, Emitter, {
    * Set the action state to "done" and marks the action for clean up, then set
    * a payload if provided. Triggers the "done" event.
    */
-  resolve (payload) {
-    if (this.set('done', payload)) {
+  resolve (...params) {
+    if (this.set('done', ...params)) {
       this._emit('done', this.payload)
     }
 
@@ -122,8 +122,8 @@ inherit(Action, Emitter, {
    * Set the action state to "cancelled" and marks the action for clean up,
    * then set a payload if provided. Triggers the "cancel" event.
    */
-  cancel (payload) {
-    if (this.set('cancelled', payload)) {
+  cancel (...params) {
+    if (this.set('cancelled', ...params)) {
       this._emit('cancel', this.payload)
     }
 

--- a/src/action.js
+++ b/src/action.js
@@ -3,6 +3,13 @@ import coroutine from './coroutine'
 import tag from './tag'
 import { inherit } from './utils'
 
+// What types are disposable?
+const DISPOSABLE = {
+  cancelled : true,
+  done      : true,
+  error     : true
+}
+
 /**
  * Actions encapsulate the process of resolving an action creator. Create an
  * action using `Microcosm::push`:
@@ -45,16 +52,16 @@ inherit(Action, Emitter, {
   /**
    * If defined, sets the payload for the action and triggers a "change" event.
    */
-  set (type, payload, disposable) {
+  set (type, payload) {
     // Ignore set if the action is already disposed.
     if (this.disposable) {
       return false
     }
 
     this.type = this.behavior[type]
-    this.disposable = disposable
+    this.disposable = DISPOSABLE.hasOwnProperty(type)
 
-    if (payload != undefined) {
+    if (payload !== undefined) {
       this.payload = payload
     }
 
@@ -68,7 +75,7 @@ inherit(Action, Emitter, {
    * the "open" event.
    */
   open (payload) {
-    if (this.set('open', payload, false)) {
+    if (this.set('open', payload)) {
       this._emit('open', this.payload)
     }
 
@@ -80,8 +87,8 @@ inherit(Action, Emitter, {
    * Triggers the "update" event.
    */
   send (payload) {
-    if (this.set('loading', payload, false)) {
-      this._emit('update', payload)
+    if (this.set('loading', payload)) {
+      this._emit('update', this.payload)
     }
 
     return this
@@ -92,8 +99,8 @@ inherit(Action, Emitter, {
    * set a payload if provided. Triggers the "error" event.
    */
   reject (payload) {
-    if (this.set('error', payload, true)) {
-      this._emit('error', payload)
+    if (this.set('error', payload)) {
+      this._emit('error', this.payload)
     }
 
     return this
@@ -104,7 +111,7 @@ inherit(Action, Emitter, {
    * a payload if provided. Triggers the "done" event.
    */
   resolve (payload) {
-    if (this.set('done', payload, true)) {
+    if (this.set('done', payload)) {
       this._emit('done', this.payload)
     }
 
@@ -116,7 +123,7 @@ inherit(Action, Emitter, {
    * then set a payload if provided. Triggers the "cancel" event.
    */
   cancel (payload) {
-    if (this.set('cancelled', payload, true)) {
+    if (this.set('cancelled', payload)) {
       this._emit('cancel', this.payload)
     }
 

--- a/src/action.js
+++ b/src/action.js
@@ -16,7 +16,7 @@ export default function Action (behavior) {
 
 inherit(Action, Emitter, {
   type      : null,
-  payload   : null,
+  payload   : undefined,
   disabled  : false,
   diposable : false,
   parent    : null,

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -9,6 +9,12 @@ test('accommodates string actions', function () {
   expect(action.type).toBe('test')
 })
 
+test('an action payload is undefined by default', function () {
+  const action = new Action('test').resolve()
+
+  expect(action.payload).toBe(undefined)
+})
+
 test('actions can be tested externally', function () {
   const repo = new Microcosm()
   const identity = n => n

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -15,6 +15,15 @@ test('an action payload is undefined by default', function () {
   expect(action.payload).toBe(undefined)
 })
 
+test('an action can intentionally be set to undefined', function () {
+  const action = new Action('test')
+
+  action.open(true)
+  action.resolve(undefined)
+
+  expect(action.payload).toBe(undefined)
+})
+
 test('actions can be tested externally', function () {
   const repo = new Microcosm()
   const identity = n => n


### PR DESCRIPTION
Action payloads may now intentionally be set to undefined. We'll also make them undefined by default.

---

Should fix #198