### PR TITLE
Improve performance and memory usage of history

### DIFF
--- a/bench/history-performance.js
+++ b/bench/history-performance.js
@@ -45,16 +45,8 @@ const results = SIZES.map(function (SIZE) {
    * the current branch.
    */
   now = time.now()
-  history.setSize()
-  stats.size = (time.now() - now) / 1000
-
-  /**
-   * Measure time to build an array of the current branch. This is used
-   * by other history operations.
-   */
-  now = time.now()
-  history.toArray()
-  stats.toArray = (time.now() - now) / 1000
+  history.adjustSize()
+  stats.adjustSize = (time.now() - now) / 1000
 
   var memoryUsage = process.memoryUsage().heapUsed - memoryBefore
 
@@ -62,9 +54,11 @@ const results = SIZES.map(function (SIZE) {
    * Measure time to dispose all nodes in the history. This also has
    * the side effect of helping to test memory leakage later.
    */
-  for (let i = 0, items = history.toArray(); i < items.length; i++) {
-    items[i].resolve(true)
-  }
+   let node = history.root
+   while (node) {
+     node.resolve(true)
+     node = node.next
+   }
   now = time.now()
   history.rollforward()
   stats.rollforward = (time.now() - now) / 1000
@@ -82,8 +76,7 @@ const results = SIZES.map(function (SIZE) {
   return {
     'Nodes': SIZE.toLocaleString(),
     '::append()': stats.build.toFixed(2) + 'ms',
-    '::toArray()': stats.toArray.toFixed(2) + 'ms',
-    '::setSize()': stats.size.toFixed(2) + 'ms',
+    '::adjustSize()': stats.adjustSize.toFixed(2) + 'ms',
     '::rollforward()': stats.rollforward.toFixed(2) + 'ms',
     'Total Memory': (memoryUsage / 1000000).toFixed(2) + 'mbs',
     'Memory Growth': stats.memory.toFixed(2) + 'mbs (' + growth.toFixed(2) + '%)'

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -5,16 +5,20 @@
  */
 
 export default function Emitter () {
-  this._events = []
+  this._events = null
 }
 
 Emitter.prototype = {
-
   /**
    * Add an event listener.
    */
   on (event, fn, scope, once) {
+    if (this._events == null) {
+      this._events = []
+    }
+
     this._events.push({ event, fn, scope, once })
+
     return this
   },
 
@@ -31,6 +35,10 @@ Emitter.prototype = {
    * no callback is provided, removes all callbacks for the given type.
    */
   off (event, fn, scope) {
+    if (this._events == null) {
+      return this
+    }
+
     var removeAll = fn == null
 
     let i = 0
@@ -51,15 +59,18 @@ Emitter.prototype = {
   },
 
   removeAllListeners () {
-    this._events.length = 0
+    this._events = null
   },
 
   /**
    * Emit `event` with the given args.
    */
   _emit (event, payload) {
-    let i = 0
+    if (this._events == null) {
+      return this
+    }
 
+    let i = 0
     while (i < this._events.length) {
       var cb = this._events[i]
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -5,6 +5,7 @@ import Realm        from './realm'
 import createEffect from './create-effect'
 import lifecycle    from './lifecycle'
 import tag          from './tag'
+import coroutine    from './coroutine'
 
 import {
   merge,
@@ -261,7 +262,11 @@ inherit(Microcosm, Emitter, {
    * @return {Action} action representaftion of the invoked function
    */
   push (behavior, ...params) {
-    return this.append(behavior).execute(params, this)
+    let action = this.append(behavior)
+
+    coroutine(action, action.behavior.apply(null, params), this)
+
+    return action
   },
 
   /**

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -2,6 +2,22 @@ import History from '../src/history'
 import Microcosm from '../src/microcosm'
 
 const action = n => n
+const toArray = function (history) {
+  let items = new Array()
+  let node  = history.focus || history.root
+
+  while (node) {
+    items.push(node)
+
+    if (node === history.head) {
+      break
+    }
+
+    node = node.next
+  }
+
+  return items
+}
 
 test('adjusts the focal point when adding a node', function () {
   const history = new History()
@@ -34,7 +50,7 @@ test('only walks through the main timeline', function () {
 
   const third = history.append(action)
 
-  expect(history.toArray()).toEqual([ first, third ])
+  expect(toArray(history)).toEqual([ first, third ])
 })
 
 test('does not walk past the focal point', function () {
@@ -45,7 +61,7 @@ test('does not walk past the focal point', function () {
   history.append(action)
   history.checkout(one)
 
-  expect(history.toArray()).toEqual([ one ])
+  expect(toArray(history)).toEqual([ one ])
 })
 
 test('properly handles forks', function () {
@@ -60,11 +76,11 @@ test('properly handles forks', function () {
   let four = history.append(action)
   let five = history.append(action)
 
-  expect(history.toArray()).toEqual([ one, two, four, five ])
+  expect(toArray(history)).toEqual([ one, two, four, five ])
 
   history.checkout(three)
 
-  expect(history.toArray()).toEqual([ one, two, three ])
+  expect(toArray(history)).toEqual([ one, two, three ])
 })
 
 test('can get the previous node in the chain', function () {
@@ -99,48 +115,52 @@ test('can determine the root node', function () {
   expect(history.root).toEqual(a)
 })
 
-test('can determine children', function () {
-  const history = new History()
-  const a = history.append(action)
-  const b = history.append(action)
+describe('children', function () {
 
-  history.checkout(a)
+  test('can determine children', function () {
+    const history = new History()
+    const a = history.append(action)
+    const b = history.append(action)
 
-  const c = history.append(action)
+    history.checkout(a)
 
-  expect(a.children).toEqual([ c, b ])
-})
+    const c = history.append(action)
 
-test('does not lose children when checking out nodes on the left', function () {
-  const history = new History()
+    expect(a.children).toEqual([ c, b ])
+  })
 
-  history.append(action)
+  test('does not lose children when checking out nodes on the left', function () {
+    const history = new History()
 
-  const b = history.append(action)
-  const c = history.append(action)
+    history.append(action)
 
-  history.checkout(b)
+    const b = history.append(action)
+    const c = history.append(action)
 
-  const d = history.append(action)
+    history.checkout(b)
 
-  expect(b.children).toEqual([ d, c ])
-})
+    const d = history.append(action)
 
-test('does not lose children when checking out nodes on the right', function () {
-  const history = new History()
+    expect(b.children).toEqual([ d, c ])
+  })
 
-  history.append(action)
+  test('does not lose children when checking out nodes on the right', function () {
+    const history = new History()
 
-  const b = history.append(action)
-  const c = history.append(action)
+    history.append(action)
 
-  history.checkout(b)
+    const b = history.append(action)
+    const c = history.append(action)
 
-  const d = history.append(action)
+    history.checkout(b)
 
-  history.checkout(c)
+    const d = history.append(action)
 
-  expect(b.children).toEqual([d, c])
+    history.checkout(c)
+
+    expect(b.children).toEqual([ d, c ])
+  })
+
 })
 
 describe('archival', function () {
@@ -167,6 +187,7 @@ describe('archival', function () {
     history.rollforward()
 
     expect(history.size).toEqual(0)
+    expect(history.root).toEqual(null)
   })
 
   test('will not archive a node if prior nodes are not complete', function () {
@@ -212,8 +233,6 @@ describe('archival', function () {
     history.rollforward()
 
     expect(one.parent).toBe(null)
-    expect(one.sibling).toBe(null)
-
     expect(two.parent).toBe(null)
   })
 
@@ -230,16 +249,6 @@ describe('archival', function () {
     expect(history.focus).toBe(null)
     expect(history.root).toBe(null)
     expect(history.head).toBe(null)
-  })
-
-})
-
-describe('toArray', function() {
-
-  test('does not generate null nodes', function() {
-    const history = new History()
-
-    expect(history.toArray()).toEqual([])
   })
 
 })

--- a/test/microcosm.test.js
+++ b/test/microcosm.test.js
@@ -26,7 +26,8 @@ test('can manipulate how many transactions are merged', function () {
   repo.push(identity, 6)
 
   expect(repo.history.size).toEqual(5)
-  expect(repo.history.toArray().map(a => a.payload)).toEqual([ 2, 3, 4, 5, 6 ])
+  expect(repo.history.root.payload).toEqual(2)
+  expect(repo.history.head.payload).toEqual(6)
 })
 
 test('can partially apply push', function () {

--- a/test/middleware/promise-middleware.test.js
+++ b/test/middleware/promise-middleware.test.js
@@ -1,27 +1,24 @@
-import Action from '../../src/action'
+import Microcosm from '../../src/microcosm'
 
 test('completes when a promise resolves', function (done) {
-  const action = new Action(n => Promise.resolve(n))
+  const repo = new Microcosm()
+  const action = repo.push(n => Promise.resolve(n))
 
   action.onDone(() => done())
-
-  action.execute(['test'])
 })
 
 test('rejects when a promise fails', function (done) {
-  const action = new Action(n => Promise.reject(n))
+  const repo = new Microcosm()
+  const action = repo.push(n => Promise.reject(n))
 
   action.onError(() => done())
-
-  action.execute(['test'])
 })
 
 test('rejects when a promise throws an error', function (done) {
-  const action = new Action(n => new Promise(function (resolve, reject) {
+  const repo = new Microcosm()
+  const action = repo.push(n => new Promise(function (resolve, reject) {
     throw 'This error is intentional'
   }))
 
   action.onError(() => done())
-
-  action.execute(['test'])
 })


### PR DESCRIPTION
This PR started out as a way to fix some edge cases when disabling actions. However along the way I discovered some pretty nice performance improvements.

It changes the way the History module traverses the action tree. Instead of building an array, it uses a linked list. Additionally, I removed some babel compilation for argument parameters in Action to avoid building an array when calling `resolve`, `error`, etc. 

### Results

- Action memory usage is roughly 1/5 of master
- Appending actions is roughly 5x faster (strange how that worked out)
- Pushing actions is roughly 2x faster

So pretty neat! Also the build size is a little smaller too.