### PR TITLE
Pass Presenter send method along with model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 11.2.0
+
+- The `withIntent` add-on correctly sets its displayName property to
+  `"withIntent(ComponentName)")`. This makes it selectable by enzyme's
+  `find` function.
+
 ## 11.1.0
 
 - Added getRepo method to presenters to allow greater control over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The `withIntent` add-on correctly sets its displayName property to
   `"withIntent(ComponentName)")`. This makes it selectable by enzyme's
   `find` function.
+- Pass `send` prop to Presenter children
 
 ## 11.1.0
 

--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -249,6 +249,25 @@ class Example extends Presenter {
 If a view is a React component, it will invoke it with the Presenter's
 model as props (including children).
 
+Views are passed the `send` method on a Presenter. This provides the
+exact same behavior as `withIntent`:
+
+```javascript
+function Button ({ send }) {
+  return <button onClick={() => send('test')}>Click me!</button>
+}
+
+class Example extends Presenter {
+  view = Button
+
+  register () {
+    return {
+      'test': () => alert("This is a test!")
+    }
+  }
+}
+```
+
 ### register()
 
 Expose "intent" subscriptions to child components. This is used with the `Form` or `withIntent`

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -113,8 +113,9 @@ function PresenterContext (props, context) {
 
   this.repo = this.getRepo()
   this.state = {}
+  this.send = this.send.bind(this)
 
-  props.presenter._connectSend(this.send.bind(this))
+  props.presenter._connectSend(this.send)
 }
 
 inherit(PresenterContext, BaseComponent, {
@@ -122,7 +123,7 @@ inherit(PresenterContext, BaseComponent, {
   getChildContext () {
     return {
       repo : this.repo,
-      send : this.send.bind(this)
+      send : this.send
     }
   },
 
@@ -146,7 +147,7 @@ inherit(PresenterContext, BaseComponent, {
   render () {
     const { presenter, parentProps } = this.props
 
-    const model = merge(parentProps, this.state)
+    const model = merge(parentProps, { send: this.send }, this.state)
 
     if (presenter.view.contextTypes || presenter.view.prototype.isReactComponent) {
       return createElement(presenter.view, model)

--- a/src/addons/with-intent.js
+++ b/src/addons/with-intent.js
@@ -33,6 +33,7 @@ export default function withIntent (Component) {
     return createElement(Component, merge({ send }, props))
   }
 
+  WithIntent.displayName = 'withIntent(' + displayName(Component) + ')'
   WithIntent.contextTypes = WithIntent.propTypes = TYPES
 
   return WithIntent

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -28,6 +28,25 @@ describe('::model', function() {
     expect(wrapper.text()).toEqual('Hello, world!')
   })
 
+  test('passes send within the model', function () {
+    let spy = jest.fn()
+
+    class Hello extends Presenter {
+      register () {
+        return {
+          'test': spy
+        }
+      }
+      view ({ send }) {
+        return <button onClick={() => send('test')} />
+      }
+    }
+
+    let wrapper = mount(<Hello place="world" />).simulate('click')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
   test('builds the view model into state', function () {
     class MyPresenter extends Presenter {
       model () {

--- a/test/addons/withIntent.test.js
+++ b/test/addons/withIntent.test.js
@@ -75,3 +75,29 @@ describe('When there is no context (called directly as a function)', function ()
   })
 
 })
+
+describe('Display name', function () {
+
+  test('sets the correct display name for stateless components', function () {
+    const Button = withIntent(function Button () {
+      return <button type="button" />
+    })
+
+    let wrapper = mount(<div><Button /></div>)
+
+    expect(wrapper.find('withIntent(Button)')).toHaveLength(1)
+  })
+
+  test('sets the correct display name for stateful components', function () {
+    const Button = withIntent(class Button extends React.Component {
+      render () {
+        return <button type="button" />
+      }
+    })
+
+    let wrapper = mount(<div><Button /></div>)
+
+    expect(wrapper.find('withIntent(Button)')).toHaveLength(1)
+  })
+
+})


### PR DESCRIPTION
We found ourselves wrapping the direct children of the Presenter component with `withIntent` quite often. This PR configures the Presenter to pass down `send` along with the model.

Fixes #203