### PR TITLE
Send fork of repo into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 11.2.1
+
+- Properly teardown event listeners that are not forks
+- Send forked repo into view
+
 ## 11.2.0
 
 - The `withIntent` add-on correctly sets its displayName property to

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -151,7 +151,7 @@ inherit(PresenterContext, BaseComponent, {
   render () {
     const { presenter, parentProps } = this.props
 
-    const model = merge(parentProps, { send: this.send }, this.state)
+    const model = merge(parentProps, { send: this.send, repo: this.repo }, this.state)
 
     if (presenter.hasOwnProperty('view') || presenter.view.prototype.isReactComponent) {
       return createElement(presenter.view, model)

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -47,6 +47,22 @@ describe('::model', function() {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('references the forked repo', function () {
+    expect.assertions(1)
+
+    let repo = new Microcosm()
+
+    class Test extends Presenter {
+      view (model) {
+        expect(model.repo.parent).toBe(repo)
+
+        return <p>Test</p>
+      }
+    }
+
+    mount(<Test repo={repo} />)
+  })
+
   test('builds the view model into state', function () {
     class MyPresenter extends Presenter {
       model () {


### PR DESCRIPTION
The repo prop from a presenter was getting sent into the view. This
commit overrides that prop with new fork.

Fixes #208

cc @greypants