### PR TITLE
Serialization should include parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 11.4.0
+
+- Serializing a fork folds over parent serialization. This should be
+  consistent with standard action dispatching.
+
+
 ## 11.3.0
 
 - Presenters now support hot module replacement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 11.4.0
 
-- Serializing a fork folds over parent serialization. This should be
+- Serializing a fork folds into parent serialization. This should be
+  consistent with standard action dispatching.
+- Deserializing a fork folds into parent deserialization. This should be
   consistent with standard action dispatching.
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcosm",
-  "version": "11.3.0",
+  "version": "11.4.0-beta.0",
   "private": true,
   "description": "Flux with actions at center stage. Write optimistic updates, cancel requests, and track changes with ease.",
   "main": "microcosm.js",

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -351,11 +351,14 @@ inherit(Microcosm, Emitter, {
    * @return {Object} The deserialized version of the provided payload.
    */
   deserialize (payload) {
-    if (payload == null) {
-      return {}
+    let base = payload ? payload : {}
+
+    if (this.parent) {
+      base = this.parent.deserialize(base)
     }
 
-    return this.dispatch(payload, lifecycle.deserialize, payload)
+
+    return this.dispatch(base, lifecycle.deserialize, base)
   },
 
   /**
@@ -365,7 +368,13 @@ inherit(Microcosm, Emitter, {
    * @return {Object} The serialized version of repo state.
    */
   serialize () {
-    return this.dispatch(this.staged, lifecycle.serialize, null)
+    let base = this.staged
+
+    if (this.parent) {
+      base = merge(base, this.parent.serialize())
+    }
+
+    return this.dispatch(base, lifecycle.serialize, null)
   },
 
   /**

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -357,7 +357,6 @@ inherit(Microcosm, Emitter, {
       base = this.parent.deserialize(base)
     }
 
-
     return this.dispatch(base, lifecycle.deserialize, base)
   },
 

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -42,3 +42,74 @@ test('passes the raw data as the second argument of deserialize', function (done
 
   repo.deserialize({ fiz: 'buzz'})
 })
+
+describe('parents', function () {
+
+  test('serialize works from parents to children', function () {
+    const parent = new Microcosm()
+    const child = parent.fork()
+
+    parent.addDomain('fiz', {
+      getInitialState: () => 'fiz',
+      serialize: word => word.toUpperCase()
+    })
+
+    child.addDomain('buzz', {
+      getInitialState: () => 'buzz',
+      serialize: word => word.toUpperCase()
+    })
+
+    expect(child.serialize()).toEqual({ fiz: 'FIZ', buzz: 'BUZZ' })
+  })
+
+  test('serializing a child with the same key works from serialization', function () {
+    const parent = new Microcosm()
+    const child = parent.fork()
+
+    parent.addDomain('fiz', {
+      getInitialState: () => 'fiz',
+      serialize: word => word + '-first'
+    })
+
+    child.addDomain('fiz', {
+      serialize: word => word + '-second'
+    })
+
+    expect(child.serialize()).toEqual({ fiz: 'fiz-first-second' })
+  })
+
+  test('deserialize works from parents to children', function () {
+    const parent = new Microcosm()
+    const child = parent.fork()
+
+    parent.addDomain('fiz', {
+      deserialize: word => word.toLowerCase()
+    })
+
+    child.addDomain('buzz', {
+      deserialize: word => word.toLowerCase()
+    })
+
+    const data = child.deserialize({ fiz: 'FIZ', buzz: 'BUZZ' })
+
+    expect(data).toEqual({ fiz: 'fiz', buzz: 'buzz' })
+  })
+
+  test('deserializing a child with the same key works from serialization', function () {
+    const parent = new Microcosm()
+    const child = parent.fork()
+
+    parent.addDomain('fiz', {
+      deserialize: word => word + '-first'
+    })
+
+    child.addDomain('fiz', {
+      deserialize: word => word + '-second'
+    })
+
+    const data = child.deserialize({ fiz: 'fiz' })
+
+    expect(data).toEqual({ fiz: 'fiz-first-second' })
+  })
+
+})


### PR DESCRIPTION
This commit fixes an issue where calling deserialize and serialize on
a fork lost access to serialization processes on parents:

```
    const parent = new Microcosm()
    const child = parent.fork()

    parent.addDomain('fiz', {
      getInitialState: () => 'fiz',
      serialize: word => word.toUpperCase()
    })

    child.addDomain('buzz', {
      getInitialState: () => 'buzz',
      serialize: word => word.toUpperCase()
    })

    expect(child.serialize()).toEqual({ fiz: 'FIZ', buzz: 'BUZZ' })
```

In this case, the parent is the owner of `fiz`. It should be responsible for initial serialization.

cc @mackermedia 