### PR TITLE
Add API for memoization

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "uglifyjs": "^2.4.10",
     "uid": "0.0.2",
     "webpack": "^2.2.0",
-    "webpack-dev-middleware": "^1.9.0",
+    "webpack-dev-middleware": "^1.10.0",
     "webpack-dev-server": "^2.2.0"
   }
 }

--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -86,7 +86,7 @@ inherit(Presenter, BaseComponent, {
    *
    * If none of the keys have changed, `this.updateState` will not set a new state.
    */
-  model (props, state) {
+  model (props, state, repo) {
     return EMPTY
   },
 
@@ -168,7 +168,7 @@ inherit(PresenterContext, BaseComponent, {
   },
 
   updatePropMap ({ presenter, parentProps, parentState }) {
-    this.propMap = presenter.model(parentProps, parentState)
+    this.propMap = presenter.model(parentProps, parentState, this.repo)
     this.propMapKeys = Object.keys(this.propMap || EMPTY)
   },
 
@@ -197,6 +197,7 @@ inherit(PresenterContext, BaseComponent, {
     for (var i = this.propMapKeys.length - 1; i >= 0; --i) {
       var key = this.propMapKeys[i]
       var entry = this.propMap[key]
+
       var value = typeof entry === 'function' ? entry(repoState) : entry
 
       if (this.state[key] !== value) {

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -449,7 +449,7 @@ inherit(Microcosm, Emitter, {
   * invocations of a computation as state changes. Useful for use inside
   * of Presenters.
    */
-  query (...args) {
+  memo (...args) {
     return () => this.compute(...args)
   },
 
@@ -457,8 +457,8 @@ inherit(Microcosm, Emitter, {
    * Return a memoized version of extract. Optionally
    * add additional processing.
    */
-  memoize (query, ...processors) {
-    let keyPaths = compileKeyPaths(query)
+  query (fragment, ...processors) {
+    let keyPaths = compileKeyPaths(fragment)
 
     let subset = null
     let answer = null

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -426,7 +426,7 @@ inherit(Microcosm, Emitter, {
    * state within Presenters.
    */
   index (name, ...args) {
-    this.indexes[name] = this.memoize(...args)
+    this.indexes[name] = this.query(...args)
 
     return this.indexes[name]
   },
@@ -439,9 +439,11 @@ inherit(Microcosm, Emitter, {
       throw new TypeError('Unable to compute missing index ' + index)
     }
 
+    let initial = this.indexes[index]()
+
     return processors.reduce((value, next) => {
       return next.call(this, value, this.state)
-    }, this.indexes[index]())
+    }, initial)
   },
 
   /**

--- a/test/computed-props.test.js
+++ b/test/computed-props.test.js
@@ -1,0 +1,103 @@
+import Microcosm from '../src/microcosm'
+
+describe('indexing', function () {
+
+  test('can save an index for later', function() {
+    let repo = new Microcosm(null, { styles: { color: 'red' } })
+
+    repo.reset({ styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let color = repo.compute('color')
+
+    expect(color).toEqual('red')
+  })
+
+  test('computing an index twice returns the same value', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color')
+
+    let a = repo.compute('color')
+    let b = repo.compute('color')
+
+    expect(a).toBe(b)
+  })
+
+  test('updates if state changes', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let a = repo.compute('color')
+
+    repo.patch({ styles: { color: 'blue' } })
+
+    let b = repo.compute('color')
+
+    expect(a).not.toBe(b)
+    expect(b).toEqual('blue')
+  })
+
+})
+
+describe('compute', function () {
+
+  it('can perform additional data processing on indexes', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let value = repo.compute('color', color => color.toUpperCase())
+
+    expect(value).toEqual('RED')
+  })
+
+})
+
+describe('query', function () {
+
+  it('returns the same result if state has not changed', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let query = repo.query('color', color => color.toUpperCase())
+
+    let a = query()
+    let b = query()
+
+    expect(a).toEqual('RED')
+    expect(a).toBe(b)
+  })
+
+  it('returns a new result if state has changed', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let query = repo.query('color', color => color.toUpperCase())
+
+    let a = query()
+
+    repo.patch({ styles: { color: 'blue' }})
+    
+    let b = query()
+
+    expect(a).toEqual('RED')
+    expect(b).toEqual('BLUE')
+  })
+
+  it('queries may run multiple processors', function () {
+    let repo = new Microcosm({}, { styles: { color: 'red' } })
+
+    repo.index('color', 'styles.color', state => state.styles.color)
+
+    let query = repo.query('color',
+                           color => color.toUpperCase(),
+                           color => color + ' - test')
+
+    expect(query()).toEqual('RED - test')
+  })
+})

--- a/test/computed-props.test.js
+++ b/test/computed-props.test.js
@@ -65,8 +65,8 @@ describe('memo', function () {
 
     let query = repo.memo('color', color => color.toUpperCase())
 
-    let a = memo()
-    let b = memo()
+    let a = query()
+    let b = query()
 
     expect(a).toEqual('RED')
     expect(a).toBe(b)

--- a/test/computed-props.test.js
+++ b/test/computed-props.test.js
@@ -56,17 +56,17 @@ describe('compute', function () {
 
 })
 
-describe('query', function () {
+describe('memo', function () {
 
   it('returns the same result if state has not changed', function () {
     let repo = new Microcosm({}, { styles: { color: 'red' } })
 
     repo.index('color', 'styles.color', state => state.styles.color)
 
-    let query = repo.query('color', color => color.toUpperCase())
+    let query = repo.memo('color', color => color.toUpperCase())
 
-    let a = query()
-    let b = query()
+    let a = memo()
+    let b = memo()
 
     expect(a).toEqual('RED')
     expect(a).toBe(b)
@@ -77,7 +77,7 @@ describe('query', function () {
 
     repo.index('color', 'styles.color', state => state.styles.color)
 
-    let query = repo.query('color', color => color.toUpperCase())
+    let query = repo.memo('color', color => color.toUpperCase())
 
     let a = query()
 
@@ -94,9 +94,9 @@ describe('query', function () {
 
     repo.index('color', 'styles.color', state => state.styles.color)
 
-    let query = repo.query('color',
-                           color => color.toUpperCase(),
-                           color => color + ' - test')
+    let query = repo.memo('color',
+                          color => color.toUpperCase(),
+                          color => color + ' - test')
 
     expect(query()).toEqual('RED - test')
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5248,6 +5248,15 @@ webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
+webpack-dev-middleware@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz#7d5be2651e692fddfafd8aaed177c16ff51f0eb8"
+  dependencies:
+    memory-fs "~0.4.1"
+    mime "^1.3.4"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+
 webpack-dev-middleware@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.9.0.tgz#a1c67a3dfd8a5c5d62740aa0babe61758b4c84aa"


### PR DESCRIPTION
This commit adds a new feature for memoizing complex state
computations.

- `query` allows you to extract a fragment of state using key paths, like `"users,ui.region"`
- `index` allows you to assign a query to a string name
- `compute` allows you to calculate an index, optionally passing functions for additional processing

I'd like to keep this a private API until we can really nail things down, but here's an example usage for one of the projects I'm testing it on:

```javascript
class StrategiesHistoricalPresenter extends Presenter {
  view = Historical

  setup (repo) {
    repo.index('series', 'strategies,ui.focused,ui.region', byRegion('strategies'))
  }

  model ({ location }, _, repo) {
    const { query } = location

    return {
      query      : query,
      region     : state => state.ui.region,
      series     : repo.memo('series', currentAggregates(query)),
      strategies : repo.memo('series', highlight(query)),
      aggregate  : repo.memo('series', highlight(query), focusedAggregate)
    }
  }
}
```