### PR TITLE
Reset and patch reject when deserialize fails. Add new test helper

### DIFF
--- a/src/addons/jest-matchers.js
+++ b/src/addons/jest-matchers.js
@@ -1,4 +1,4 @@
-import { tag, getRegistration } from '../microcosm'
+import Microcosm, { Action, tag, get, getRegistration } from '../microcosm'
 
 expect.extend({
 
@@ -18,6 +18,11 @@ expect.extend({
   },
 
   toHaveStatus (action, status) {
+    if (action instanceof Action === false) {
+      throw new TypeError("toHaveStatus expects an Action. Received " +
+                          (action ? "a " + action.constructor.name : action) + ".")
+    }
+
     let operator = this.isNot ? 'not to' : 'to'
     let pass = action.is(status)
 
@@ -25,6 +30,30 @@ expect.extend({
       pass: pass,
       message: () => {
         return `Expected action ${operator} to be"${status}".`
+      }
+    }
+  },
+
+  toHaveState (repo, key, value) {
+    if (repo instanceof Microcosm === false) {
+      throw new TypeError("toHaveState expects a Microcosm. Received " +
+                           (repo ? "a " + repo.constructor.name : repo) + ".")
+    }
+
+    let operator = this.isNot ? 'not to' : 'to'
+    let pass = false
+    let actual = get(repo.state, key)
+
+    if (arguments.length > 2) {
+      pass = actual === value
+    } else {
+      pass = actual !== undefined
+    }
+
+    return {
+      pass: pass,
+      message: () => {
+        return `Expected repo state at "${key}" ${operator} be ${value}. Found ${actual}.`
       }
     }
   }

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,15 +1,27 @@
 import tag from './tag'
 
-export const RESET = tag(function (data, deserialize) {
+function sandbox (data, deserialize) {
   return (action, repo) => {
-    action.resolve(deserialize ? repo.deserialize(data) : data)
+    let payload = data
+
+    if (deserialize) {
+      try {
+        payload = repo.deserialize(data)
+      } catch (error) {
+        action.reject(error)
+      }
+    }
+
+    action.resolve(payload)
   }
+}
+
+export const RESET = tag(function reset (data, deserialize) {
+  return sandbox(data, deserialize)
 }, 'reset')
 
-export const PATCH = tag(function (data, deserialize) {
-  return (action, repo) => {
-    action.resolve(deserialize ? repo.deserialize(data) : data)
-  }
+export const PATCH = tag(function patch (data, deserialize) {
+  return sandbox(data, deserialize)
 }, 'patch')
 
 export const ADD_DOMAIN = 'addDomain'

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -32,10 +32,10 @@ it('actions can be tested externally', function () {
   })
 
   repo.append(identity).open()
-  expect(repo.state.test).toBe('open')
+  expect(repo).toHaveState('test', 'open')
 
   repo.append(identity).resolve()
-  expect(repo.state.test).toBe('done')
+  expect(repo).toHaveState('test', 'done')
 })
 
 it('handles listeners with no callback', function () {
@@ -488,7 +488,7 @@ describe('::toggle', function() {
     repo.push('action', 2)
     repo.push('action', 1).toggle()
 
-    expect(repo.state.count).toEqual(2)
+    expect(repo).toHaveState('count', 2)
   })
 
   it('it will not dispatch an action disabled in the middle', function () {
@@ -511,7 +511,7 @@ describe('::toggle', function() {
 
     second.toggle()
 
-    expect(repo.state.count).toEqual(4)
+    expect(repo).toHaveState('count', 4)
   })
 
 })

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -23,13 +23,13 @@ it('does not mutate base state on prior dispatches', function () {
 
   repo.push(mutation)
   expect(repo.history.size).toEqual(0)
-  expect(repo.state.toggled).toEqual(true)
+  expect(repo).toHaveState('toggled', true)
 
   repo.push(mutation)
   expect(repo.history.size).toEqual(0)
-  expect(repo.state.toggled).toEqual(false)
+  expect(repo).toHaveState('toggled', false)
 
   repo.push(mutation)
   expect(repo.history.size).toEqual(0)
-  expect(repo.state.toggled).toEqual(true)
+  expect(repo).toHaveState('toggled', true)
 })

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -11,7 +11,7 @@ describe('Creation modes', function () {
       }
     })
 
-    expect(repo.state.count).toBe(0)
+    expect(repo).toHaveState('count', 0)
   })
 
   it('object - original primitive is not mutated', function () {
@@ -39,7 +39,7 @@ describe('Creation modes', function () {
 
     repo.addDomain('count', Counter)
 
-    expect(repo.state.count).toBe(0)
+    expect(repo).toHaveState('count', 0)
   })
 
   it('class - extends domain', function () {
@@ -53,7 +53,7 @@ describe('Creation modes', function () {
 
     repo.addDomain('count', Counter)
 
-    expect(repo.state.count).toBe(0)
+    expect(repo).toHaveState('count', 0)
   })
 
 })

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -144,7 +144,7 @@ describe('state', function () {
 
     const Effect = {
       handler (repo) {
-        expect(repo.state.test).toBe(true)
+        expect(repo).toHaveState('test', true)
       },
       register() {
         return {

--- a/test/mutation.test.js
+++ b/test/mutation.test.js
@@ -19,7 +19,7 @@ it('writes to repo state', function (done) {
   })
 
   repo.push(action, true).onDone(() => {
-    expect(repo.state.test).toBe(true)
+    expect(repo).toHaveState('test', true)
     done()
   })
 })

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -32,7 +32,7 @@ it('returns the same state if a handler is not provided', function () {
   })
 
   return repo.push(action).onDone(function() {
-    expect(repo.state.test).toEqual('test')
+    expect(repo).toHaveState('test', 'test')
   })
 })
 

--- a/test/rollbacks.test.js
+++ b/test/rollbacks.test.js
@@ -36,11 +36,11 @@ it('does not rollforward the same actions twice', function () {
   b.resolve({ id: 2 })
   c.resolve({ id: 3 })
 
-  expect(repo.state.messages[0].pending).not.toBeDefined()
-  expect(repo.state.messages[1].pending).not.toBeDefined()
-  expect(repo.state.messages[2].pending).not.toBeDefined()
+  expect(repo).toHaveState(['messages', 0, 'pending'], undefined)
+  expect(repo).toHaveState(['messages', 1, 'pending'], undefined)
+  expect(repo).toHaveState(['messages', 2, 'pending'], undefined)
 
-  expect(repo.state.messages.length).toEqual(3)
+  expect(repo).toHaveState(['messages', 'length'], 3)
 })
 
 it('remembers the archive point', function () {

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -54,8 +54,8 @@ describe('deserialize', function () {
       }
     })
 
-    return repo.patch({}).onDone(function() {
-      expect(repo.state).toEqual({ fiz: true })
+    return repo.patch({}, true).onDone(function() {
+      expect(repo).toHaveState('fiz', true)
     })
   })
 
@@ -71,17 +71,6 @@ describe('deserialize', function () {
     let answer = repo.deserialize('{ "fiz": "buzz"}')
 
     expect(answer).toEqual({ fiz: 'BUZZ' })
-  })
-
-  it('rejects if there is a JSON parse error deserialization fails', function () {
-    const repo = new Microcosm()
-
-    // This is invalid
-    function badPatch () {
-      repo.patch("{ test: deserialize }", true)
-    }
-
-    expect(badPatch).toThrow('Unexpected token')
   })
 
 })


### PR DESCRIPTION
Reset and patch return an action. This PR sets those actions up so that they are rejected whenever deserializing their payloads fail.

Deserialize still raises an exception. 

I've also added a new test helper for quickly testing repo state in a safe way. 