### PR TITLE
Presenter updates

### DIFF
--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -8,9 +8,11 @@
 ## Overview
 
 The Presenter add-on makes it easier to keep application logic high
-within a component tree. It is designed specifically to extract and
-compute properties coming from a Microcosm instance and efficiently
-send them down as `props` to child "passive view" React components.
+within a component tree. It subscribes to state changes via a
+`getModel` method, designed specifically to extract and compute
+properties coming from a Microcosm instance. When state changes, model
+keys are efficiently sent down as props to child “passive view” React
+components.
 
 Presenters also make it easy for components deep within a component
 tree to communicate without passing a long chain of props. The

--- a/docs/api/presenter.md
+++ b/docs/api/presenter.md
@@ -199,7 +199,9 @@ changes.
 
 ### `view`
 
-If a Presenter has a `view` property, it create the associated component instead of calling `render`. The `view` component is given the latest model data:
+If a Presenter has a `view` property, it creates the associated component
+instead of calling `render`. The `view` component is given the latest model
+data:
 
 ```javascript
 function Message ({ message }) {

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -146,7 +146,7 @@ import Presenter from 'microcosm/addons/presenter'
 
 class Planets extends Presenter {
 
-  view () {
+  render () {
     return (
       <ul>
         <li>Mercury</li>
@@ -207,7 +207,7 @@ import PlanetList from '../views/planet-list'
 
 class Planets extends Presenter {
 
-  view () {
+  render () {
     return <PlanetList />
   }
 
@@ -217,13 +217,12 @@ export default Planets
 
 ```
 
-Awesome. Well, not _really_. Now the `PlanetList` view components knows
+Awesome. Well, not _really_. Now the `PlanetList` component knows
 all about the data. It shouldn't care whether or not Pluto's a _real_
 planet. Let's fix that.
 
-We need to prepare data in the presenter to send down into the
-view. Presenters can implement a `model` method that to do just
-that:
+We need to prepare data in the presenter to send down into the `PlanetList`
+view. Presenters can implement a `getModel` method that to do just that:
 
 ```javascript
 // src/presenters/planets
@@ -233,13 +232,15 @@ import PlanetList from '../views/planet-list'
 
 class Planets extends Presenter {
 
-  model () {
+  getModel () {
     return {
       planets: () => ['Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto']
     }
   }
 
-  view ({ planets }) {
+  render () {
+    const { planets } = this.model
+
     return <PlanetList planets={planets} />
   }
 
@@ -322,14 +323,16 @@ import PlanetList from '../views/planet-list'
 
 class Planets extends Presenter {
 
-  model () {
+  getModel () {
     return {
       // I'm new. Pull planets out of the repo's state
       planets: state => state.planets
     }
   }
 
-  view ({ planets }) {
+  render () {
+    const { planets } = this.model
+
     return <PlanetList planets={planets} />
   }
 
@@ -377,16 +380,16 @@ function:
 import {getPlanets} from '../actions/planets'
 
 const Planets = {
-  getInitialState() {
+  getInitialState () {
     // Remember, we put the planets data into the action
     return []
   },
 
-  append(planets, data) {
+  append (planets, data) {
     return planets.concat(data)
   },
 
-  register() {
+  register () {
     return {
       // Curious? This works because Microcosm assigns a unique
       // toString() method to each action pushed into it. That means
@@ -415,17 +418,19 @@ import {getPlanets} from '../actions/planets'
 
 class Planets extends Presenter {
 
-  setup(repo) {
+  setup (repo) {
     repo.push(getPlanets)
   }
 
-  model () {
+  getModel () {
     return {
       planets: state => state.planets
     }
   }
 
-  view ({ planets }) {
+  render () {
+    const { planets } = this.model
+
     return <PlanetList planets={planets} />
   }
 


### PR DESCRIPTION
Whew! I finally wrapped this up! This implements the new updates to Presenters:

```javascript
class SolarSystem extends Presenter {

  setup () {
    // runs before `this.getModel` has executed. Useful for setting up a repo fork
  }

  ready () {
    // runs after setup, and the first model calculation
    console.log(this.model) // [{ id: "mercury" }, { id : "venus" } ...]
  }

  getModel () {
    return {
      planets: state => state.planets
    }
  }

  render () {
    const { planets } = this.model
    return <PlanetsView planets={planets} />
  }
}
```

- Presenters that do not implement a model do not listen to repo changes.
- `view` always calls React.createElement
- `render` works as an other React component
- Presenters have access to the current calculated model via `this.model`
- The `update` hook has access to the latest model
- Added `ready`, a hook that fires after setup that has access to the most recent model.
- `getModel` can no longer return a function

Hopefully this makes Presenters feel a _bit_ less magical, and more idiomatic to React.