### PR TITLE
General utility improvements, add update utility helper

### DIFF
--- a/docs/api/data-utilities.md
+++ b/docs/api/data-utilities.md
@@ -79,9 +79,8 @@ let next = update(votes, 'yay', n => n + 1)
 console.log(next) // { yay: 1, nay: 0 }
 ```
 
-`update` also excepts a fallback value. If the provided target is missing,
-the keypath is missing, the processor function will be called with the fallback
-value:
+`update` also accepts a fallback value. If the provided keypath is missing, the
+processor function will be called with the fallback value:
 
 ```javascript
 import { update } from 'microcosm'

--- a/docs/api/data-utilities.md
+++ b/docs/api/data-utilities.md
@@ -65,6 +65,33 @@ let next = set(state, ['planets', 'earth', 'color'], blue)
 console.log(next === subject) // true
 ```
 
+## update(target, key, value, processor, fallback)
+
+Extract a value from a keypath, then call a function on that value and assign
+the result at the same point. This is useful for modifying values in-place:
+
+```javascript
+import { update } from 'microcosm'
+
+let votes = { yay: 0, nay: 0 }
+let next = update(votes, 'yay', n => n + 1)
+
+console.log(next) // { yay: 1, nay: 0 }
+```
+
+`update` also excepts a fallback value. If the provided target is missing,
+the keypath is missing, the processor function will be called with the fallback
+value:
+
+```javascript
+import { update } from 'microcosm'
+
+let votes = { yay: 0, nay: 0 }
+let next = update(votes, 'undecided', n => n + 1, 0)
+
+console.log(next) // { yay: 0, nay: 0, undecided: 1 }
+```
+
 ## merge(...objects)
 
 Non-destructively merge together the keys of any number of objects,

--- a/src/realm.js
+++ b/src/realm.js
@@ -1,3 +1,4 @@
+import MetaDomain from './meta-domain'
 import getDomainHandlers from './get-domain-handlers'
 
 import {
@@ -74,7 +75,9 @@ Realm.prototype = {
 
   prune (state, data) {
     return this.reduce(function (next, key) {
-      return set(next, key, get(data, key))
+      let value = get(data, key)
+
+      return value === undefined ? next : set(next, key, value)
     }, state)
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,17 +98,17 @@ export function get (object, path, fallback) {
  * Non-destructively assign a value to a provided object at a given key. If the
  * value is the same, don't do anything. Otherwise return a new object.
  */
-export function set (object, path, goal) {
+export function set (object, path, value) {
   // Ensure we're working with a key path, like: ['a', 'b', 'c']
   path = castPath(path)
 
   let len  = path.length
 
   if (len <= 0) {
-    return goal
+    return value
   }
 
-  if (get(object, path) === goal) {
+  if (get(object, path) === value) {
     return object
   }
 
@@ -118,23 +118,23 @@ export function set (object, path, goal) {
   // For each key in the path...
   for (var i = 0; i < len; i++) {
     let key = path[i]
-    let value = goal
+    let next = value
 
     // Are we at the end?
     if (i < len - 1) {
       // No: Check to see if the key is already assigned,
       if (key in node) {
         // If yes, clone that value
-        value = clone(node[key])
+        next = clone(node[key])
       } else {
         // Otherwise assign an object so that we can keep drilling down
-        value = {}
+        next = {}
       }
     }
 
     // Assign the value, then continue on to the next iteration of the loop
     // using the next step down
-    node[key] = value
+    node[key] = next
     node = node[key]
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,11 +158,14 @@ export function createOrClone (target, options, repo) {
   return Object.create(target)
 }
 
-
 /**
  * A helper combination of get and set
  */
 export function update (state, path, fn, fallback) {
+  if (typeof fn !== 'function') {
+    return set(state, path, fn)
+  }
+
   let last = get(state, path, fallback)
   let next = fn(last)
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -323,4 +323,11 @@ describe('update', function () {
 
     expect(next.styles.padding).toEqual(10)
   })
+
+  it('can set a non-function value, proxying set', function () {
+    let next = update(subject, 'styles.padding', 10)
+
+    expect(next.styles.padding).toEqual(10)
+  })
+
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -50,7 +50,7 @@ describe('clone', function () {
     expect(clone(null)).toBe(null)
   })
 
-  it('does not undefined null', function () {
+  it('does not clone undefined', function () {
     expect(clone(undefined)).toBe(undefined)
   })
 })


### PR DESCRIPTION
Updates utility methods to avoid recursion, offering a small perf boost. Also allows keys to be set as dot notation paths like:

```javascript
set(obj, 'a.b.c', value)
```

It also adds an `update` helper. Often times, we want to modify data in place. This commit adds an `update` helper that works like a combination of `get` and `set`:

```javascript
import { update } from 'microcosm'

let votes = { yay: 0, nay: 0 }
let next = update(votes, 'yay', n => n + 1)

console.log(next) // { yay: 1, nay: 0 }
```

`update` also excepts a fallback value. If the provided target is missing, the keypath is missing, the processor function will be called with the fallback value:

```javascript
import { update } from 'microcosm'

let votes = { yay: 0, nay: 0 }
let next = update(votes, 'undecided', n => n + 1, 0)

console.log(next) // { yay: 0, nay: 0, undecided: 1 }
```