### PR TITLE
History improvements

### DIFF
--- a/bench/history-performance.js
+++ b/bench/history-performance.js
@@ -34,7 +34,7 @@ const results = SIZES.map(function (SIZE) {
    */
   var now = time.now()
   for (var k = SIZE; k >= 0; k--) {
-    history.append(action)
+    history.append(action, 'done')
   }
   stats.build = ((time.now() - now) / 1000)
 
@@ -43,8 +43,8 @@ const results = SIZES.map(function (SIZE) {
    * the current branch.
    */
   now = time.now()
-  history.adjustSize()
-  stats.adjustSize = (time.now() - now) / 1000
+  history.setActiveBranch()
+  stats.setActiveBranch = (time.now() - now) / 1000
 
   var memoryUsage = process.memoryUsage().heapUsed - memoryBefore
 
@@ -52,13 +52,8 @@ const results = SIZES.map(function (SIZE) {
    * Measure time to dispose all nodes in the history. This also has
    * the side effect of helping to test memory leakage later.
    */
-   let node = history.root
-   while (node) {
-     node.resolve(true)
-     node = node.next
-   }
   now = time.now()
-  history.rollforward()
+  history.reconcile(history.root)
   stats.rollforward = (time.now() - now) / 1000
 
   /**
@@ -74,7 +69,7 @@ const results = SIZES.map(function (SIZE) {
   return {
     'Nodes': SIZE.toLocaleString(),
     '::append()': stats.build.toFixed(2) + 'ms',
-    '::adjustSize()': stats.adjustSize.toFixed(2) + 'ms',
+    '::setActiveBranch()': stats.setActiveBranch.toFixed(2) + 'ms',
     '::rollforward()': stats.rollforward.toFixed(2) + 'ms',
     'Total Memory': (memoryUsage / 1000000).toFixed(2) + 'mbs',
     'Memory Growth': stats.memory.toFixed(2) + 'mbs (' + growth.toFixed(2) + '%)'

--- a/src/action.js
+++ b/src/action.js
@@ -15,7 +15,10 @@ export default function Action (command, history, status) {
 
   this.id = this.history.getId()
   this.command = tag(command)
-  this.status = status || 'inactive'
+
+  if (status) {
+    this.status = status
+  }
 }
 
 inherit(Action, Emitter, {

--- a/src/action.js
+++ b/src/action.js
@@ -5,18 +5,20 @@ import { ACTION_STATES } from './constants'
 import { inherit } from './utils'
 
 /**
- * Actions encapsulate the process of resolving an action creator. Create an
- * action using `Microcosm::push`:
+ * Actions encapsulate the process of resolving an action
+ * creator. Create an action using `Microcosm::push`:
  */
-export default function Action (command, history) {
+export default function Action (command, history, status) {
   Emitter.call(this)
 
-  this.command = tag(command)
   this.history = history || new History()
+
+  this.id = this.history.getId()
+  this.command = tag(command)
+  this.status = status || 'inactive'
 }
 
 inherit(Action, Emitter, {
-  type       : null,
   status     : 'inactive',
   payload    : undefined,
   disabled   : false,
@@ -33,7 +35,7 @@ inherit(Action, Emitter, {
   toggle () {
     this.disabled = !this.disabled
 
-    this.history.invalidate()
+    this.history.reconcile(this)
 
     return this
   },
@@ -44,7 +46,6 @@ inherit(Action, Emitter, {
       this.onError(reject)
     }).then(pass, fail)
   }
-
 })
 
 /**

--- a/src/addons/jest-matchers.js
+++ b/src/addons/jest-matchers.js
@@ -62,7 +62,8 @@ expect.extend({
     return {
       pass: pass,
       message: () => {
-        return `Expected repo state at "${path}" ${operator} be ${value}. Found ${actual}.`
+        return `Expected "${path}" in repo.state ${operator} be ${JSON.stringify(value)} ` +
+               `but it is ${actual}.`
       }
     }
   }

--- a/src/archive.js
+++ b/src/archive.js
@@ -1,0 +1,25 @@
+/**
+ * Keep track of prior action states according to an action's id
+ */
+
+export default function Archive () {
+  this.pool = {}
+}
+
+Archive.prototype = {
+  get (action) {
+    return this.pool[action.id]
+  },
+
+  has (action) {
+    return this.pool.hasOwnProperty(action.id)
+  },
+
+  set (action, state) {
+    this.pool[action.id] = state
+  },
+
+  remove (action) {
+    delete this.pool[action.id]
+  }
+}

--- a/src/realm.js
+++ b/src/realm.js
@@ -4,6 +4,7 @@ import getDomainHandlers from './get-domain-handlers'
 import {
   get,
   set,
+  castPath,
   createOrClone
 } from './utils'
 
@@ -21,7 +22,7 @@ Realm.prototype = {
   register (action) {
     let type = action.command[action.status]
 
-    if (this.registry[type] == null) {
+    if (typeof this.registry[type] === 'undefined') {
       this.registry[type] = getDomainHandlers(this.domains, action)
     }
 
@@ -31,7 +32,7 @@ Realm.prototype = {
   add (key, config, options) {
     let domain = createOrClone(config, options, this.repo)
 
-    this.domains.push([key, domain])
+    this.domains.push([castPath(key), domain])
 
     // Reset the registry
     this.registry = {}
@@ -67,7 +68,7 @@ Realm.prototype = {
       }
 
       return memo
-    }, seed || {})
+    }, seed)
   },
 
   prune (state, data) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,12 @@
-const EMPTY_ARRAY = []
-
+const SPLITTER = '.'
 export function castPath (value) {
-  if (Array.isArray(value)) {
+  if (value == null) {
+    return []
+  } else if (Array.isArray(value)) {
     return value
-  } else if (value == null) {
-    return EMPTY_ARRAY
   }
 
-  return typeof value === 'string' ? value.split('.') : [value]
+  return typeof value === 'string' ? value.split(SPLITTER) : [value]
 }
 
 /**
@@ -56,6 +55,26 @@ export function merge () {
   return copy
 }
 
+export function backfill (subject, properties) {
+  if (subject == null) {
+    return properties
+  }
+
+  let copy = subject
+
+  for (var key in properties) {
+    if (copy.hasOwnProperty(key) === false) {
+      if (copy === subject) {
+        copy = clone(subject)
+      }
+
+      copy[key] = properties[key]
+    }
+  }
+
+  return copy
+}
+
 /**
  * Basic prototypal inheritence
  */
@@ -73,12 +92,12 @@ export function inherit (Child, Ancestor, proto) {
  * Retrieve a value from an object. If no key is provided, just return the
  * object.
  */
-export function get (object, path, fallback) {
+export function get (object, key, fallback) {
   if (object == null) {
     return fallback
   }
 
-  path = castPath(path)
+  let path = castPath(key)
 
   for (var i = 0, len = path.length; i < len; i++) {
     let value = object == null ? undefined : object[path[i]]
@@ -98,9 +117,9 @@ export function get (object, path, fallback) {
  * Non-destructively assign a value to a provided object at a given key. If the
  * value is the same, don't do anything. Otherwise return a new object.
  */
-export function set (object, path, value) {
+export function set (object, key, value) {
   // Ensure we're working with a key path, like: ['a', 'b', 'c']
-  path = castPath(path)
+  let path = castPath(key)
 
   let len  = path.length
 

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -894,8 +894,8 @@ describe('intercepting actions', function() {
 
     wrapper.find(View).simulate('click')
 
-    expect(top.history.size).toBe(0)
-    expect(bottom.history.size).toBe(1)
+    expect(top.history.size).toBe(1)
+    expect(bottom.history.size).toBe(2)
   })
 
   it('intents do not bubble to different repo types even if not forking', function () {
@@ -921,8 +921,8 @@ describe('intercepting actions', function() {
 
     wrapper.find(View).simulate('click')
 
-    expect(top.history.size).toBe(0)
-    expect(bottom.history.size).toBe(1)
+    expect(top.history.size).toBe(1)
+    expect(bottom.history.size).toBe(2)
   })
 
   it('forwards intents to the repo as actions', function () {

--- a/test/unit/history/archive.test.js
+++ b/test/unit/history/archive.test.js
@@ -23,12 +23,12 @@ describe('History::archive', function () {
     two.resolve()
 
     // Three should be ignored!
-    history.rollforward()
+    history.archive()
 
-    expect(history.size).toEqual(0)
-    expect(history.root).toBe(null)
+    expect(history.size).toEqual(1)
+    expect(history.root).toBe(two)
     // This is two because we checked out two early
-    expect(history.head).toBe(null)
+    expect(history.head).toBe(two)
   })
 
   it('will not archive a node if prior nodes are not complete', function () {
@@ -45,7 +45,7 @@ describe('History::archive', function () {
 
     history.archive()
 
-    expect(history.size).toBe(2)
+    expect(history.size).toBe(3)
   })
 
   it('archives all completed actions', function () {
@@ -63,7 +63,7 @@ describe('History::archive', function () {
     history.archive()
 
     // 1 because we have an unresolved action remaining
-    expect(history.size).toBe(2)
+    expect(history.size).toBe(1)
   })
 
   it('archived nodes have no relations', function () {
@@ -101,9 +101,9 @@ describe('History::archive', function () {
     history.append(action)
     history.append(action)
 
-    history.rollforward()
+    history.archive()
 
     expect(history.root).toEqual(a)
   })
-
+  
 })

--- a/test/unit/history/checkout.test.js
+++ b/test/unit/history/checkout.test.js
@@ -41,6 +41,14 @@ describe('History::checkout', function () {
     expect(top.next).toEqual(null)
   })
 
+  it('raises an exception if checking out a null action', function () {
+    const history = new History()
+
+    history.append(action)
+
+    expect(() => history.checkout()).toThrow()
+  })
+
   it('properly handles forked branches', function () {
     let history = new History()
 
@@ -54,11 +62,11 @@ describe('History::checkout', function () {
     let four = history.append(action)
     let five = history.append(action)
 
-    expect(history.toArray()).toEqual([ two, four, five ])
+    expect(history.toArray()).toEqual([ one, two, four, five ])
 
     history.checkout(three)
 
-    expect(history.toArray()).toEqual([ two, three ])
+    expect(history.toArray()).toEqual([ one, two, three ])
   })
 
 })

--- a/test/unit/history/toArray.test.js
+++ b/test/unit/history/toArray.test.js
@@ -7,9 +7,12 @@ describe('History::toArray', function () {
     const history = new History()
 
     let one = history.append(action)
+
     history.append(action)
     history.append(action)
     history.checkout(one)
+
+    history.archive()
 
     expect(history.toArray()).toEqual([ one ])
   })
@@ -25,7 +28,11 @@ describe('History::toArray', function () {
 
     const third = history.append(action)
 
-    expect(history.toArray()).toEqual([ first, third ])
+    history.archive()
+
+    const ids = history.map(n => n.id)
+
+    expect(ids).toEqual([ first.id, third.id ])
   })
 
 })

--- a/test/unit/microcosm/dispatch.test.js
+++ b/test/unit/microcosm/dispatch.test.js
@@ -24,15 +24,15 @@ describe('Microcosm::dispatch', function () {
     })
 
     repo.push(mutation)
-    expect(repo.history.size).toEqual(0)
+    expect(repo.history.size).toEqual(1)
     expect(repo).toHaveState('toggled', true)
 
     repo.push(mutation)
-    expect(repo.history.size).toEqual(0)
+    expect(repo.history.size).toEqual(1)
     expect(repo).toHaveState('toggled', false)
 
     repo.push(mutation)
-    expect(repo.history.size).toEqual(0)
+    expect(repo.history.size).toEqual(1)
     expect(repo).toHaveState('toggled', true)
   })
 

--- a/test/unit/reconciliation.test.js
+++ b/test/unit/reconciliation.test.js
@@ -1,0 +1,110 @@
+import Microcosm from '../../src/microcosm'
+
+describe('Reconciliation', function() {
+  const action = n => n
+
+  it('only interates over the point of reconciliation', function() {
+    const repo = new Microcosm({ maxHistory: Infinity })
+    const handler = jest.fn((a, b) => a + b)
+
+    repo.addDomain('count', {
+      getInitialState() {
+        return 0
+      },
+      register () {
+        return { [action]: handler }
+      }
+    })
+
+    let one = repo.append(action)
+    let two = repo.append(action)
+    let three = repo.append(action)
+
+    expect(repo).toHaveState('count', 0)
+
+    one.resolve(1)
+    expect(repo).toHaveState('count', 1)
+
+    two.resolve(2)
+    expect(repo).toHaveState('count', 3)
+
+    three.resolve(3)
+    expect(repo).toHaveState('count', 6)
+
+    expect(handler).toHaveBeenCalledTimes(3)
+  })
+
+  it('reapplies future actions if a prior action updates', function() {
+    const repo = new Microcosm({ maxHistory: Infinity })
+    const handler = jest.fn((a, b) => a + b)
+
+    repo.addDomain('count', {
+      getInitialState() {
+        return 0
+      },
+      register () {
+        return { [action]: handler }
+      }
+    })
+
+    let one = repo.append(action)
+    let two = repo.append(action)
+    let three = repo.append(action)
+
+    expect(repo).toHaveState('count', 0)
+
+    three.resolve(3)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(repo).toHaveState('count', 3)
+
+    two.resolve(2)
+    expect(handler).toHaveBeenCalledTimes(3)
+    expect(repo).toHaveState('count', 5)
+
+    one.resolve(1)
+    expect(handler).toHaveBeenCalledTimes(6)
+    expect(repo).toHaveState('count', 6)
+  })
+
+  it('archived actions are removed from the archive', function() {
+    const repo = new Microcosm()
+
+    let one = repo.append('a')
+    let two = repo.append('b')
+    let three = repo.append('c')
+
+    three.resolve()
+    two.resolve()
+    one.resolve()
+
+    // Should be gone
+    expect(repo.archive.has(one)).toBe(false)
+    // We need two for rolling forward changes from three
+    expect(repo.archive.has(two)).toBe(true)
+    // We need three because it is the root
+    expect(repo.archive.has(three)).toBe(true)
+  })
+
+  it('pushing actions while the root is "open" does not result in extra invocations', function() {
+    const repo = new Microcosm({ maxHistory: Infinity })
+    const handler = jest.fn((a, b) => a + b)
+
+    repo.addDomain('count', {
+      getInitialState() {
+        return 0
+      },
+      register () {
+        return { [action]: handler }
+      }
+    })
+
+    let one = repo.append(action)
+
+    repo.append(action).resolve(1)
+    repo.append(action).resolve(2)
+    repo.append(action).resolve(3)
+
+    expect(repo).toHaveState('count', 6)
+    expect(handler).toHaveBeenCalledTimes(3)
+  })
+})

--- a/test/unit/utils/backfill.test.js
+++ b/test/unit/utils/backfill.test.js
@@ -1,0 +1,47 @@
+import {
+  backfill
+} from '../../../src/utils'
+
+describe('Utils.backfill', function () {
+
+  it('adds missing keys to an object', function () {
+    let styles = backfill({}, { color: 'blue' })
+
+    expect(styles.color).toEqual('blue')
+  })
+
+  it('does not add keys already in an object', function () {
+    let styles = backfill({ color: 'red' }, { color: 'blue' })
+
+    expect(styles.color).toEqual('red')
+  })
+
+  it('returns a new object if a key is added', function () {
+    let original = {}
+    let styles = backfill(original, { color: 'blue', font: 'helvetica' })
+
+    expect(styles).not.toBe(original)
+  })
+
+  it('does not return a new object if nothing changes', function () {
+    let original = { color: 'red' }
+    let styles = backfill(original, { color: 'blue' })
+
+    expect(styles).toBe(original)
+  })
+
+  it('returns the filling object if the subject is null', function () {
+    let filler = { color: 'blue' }
+    let styles = backfill(null, filler)
+
+    expect(styles).toBe(filler)
+  })
+
+  it('handles if the filling object is null', function () {
+    let original = { color: 'blue' }
+    let styles = backfill(original, null)
+
+    expect(styles).toBe(original)
+  })
+
+})


### PR DESCRIPTION
I'm working on an undo/redo feature on a project and I already bumped into issues where we over-eagerly rollback actions. So I fixed it. This commit changes the action resolution algorithm so that history only needs to roll back to the point of change, preventing excessive Domain handler modification.

For example, assuming the following tree:

```
1-done -> 2-open -> 3-open -> 4-open -> 5-open -> 6-done
```

**Before:**

1. action 5 finishes: Process 2,3,4,5,6
2. action 4 finishes: Process 2,3,4,5,6
3. action 3 finishes: Process 2,3,4,5,6
4. action 2 finishes: Process 2,3,4,5,6
5. Mark 6 as the next root

**After:**

1. action 5 finishes: Process 5,6
2. action 4 finishes: Process 4,5,6
3. action 3 finishes: Process 3,4,5,6
4. action 2 finishes: Process 2,3,4,5,6
5. Mark 6 as the next root

This also got rid of the need for a bunch of null checks, which makes things faster and cleaner.

--- 

Fix for https://github.com/vigetlabs/microcosm/issues/226