### PR TITLE
Invoke should not run on removed repos

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -46,7 +46,7 @@ History.prototype = {
     let repos = this.repos
 
     for (var i = 0; i < repos.length; i++) {
-      console.assert(repos[i], `No repo. Was it removed before invoke could run ${method}?`)
+      console.assert(repos[i], `Missing repo! Was it removed before it could run repo.${method}?`)
       repos[i][method](payload)
     }
   },

--- a/src/history.js
+++ b/src/history.js
@@ -45,7 +45,8 @@ History.prototype = {
   invoke (method, payload) {
     let repos = this.repos
 
-    for (var i = 0, len = repos.length; i < len; i++) {
+    for (var i = 0; i < repos.length; i++) {
+      console.assert(repos[i], `No repo. Was it removed before invoke could run ${method}?`)
       repos[i][method](payload)
     }
   },

--- a/test/unit/history/invoke.test.js
+++ b/test/unit/history/invoke.test.js
@@ -1,0 +1,23 @@
+import History from '../../../src/history'
+import Microcosm from '../../../src/microcosm'
+
+describe('History::invoke', function() {
+
+  it('it does invoke a repo that no longer exists', function() {
+    let parent = new Microcosm()
+    let child = parent.fork()
+
+    parent.on('change', () => child.teardown())
+
+    jest.spyOn(child, 'release')
+
+    parent.addDomain('test', {
+      getInitialState() {
+        return false
+      }
+    })
+
+    expect(child.release).not.toHaveBeenCalled()
+  })
+
+})


### PR DESCRIPTION
This commit fixes a bug where Microcosm would raise an exception if a
fork was removed from history as the result of a parent changing. It
also adds an assertion to make it clearer during testing.

Sorry, @dce :(