### PR TITLE
Properly release state changes to children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 12.1.2
+
+- Fixed issue where parent repos would send out changes before
+  children could reconcile.
+
 ## 12.1.1
 
 - Fixed length caching issue where history would still try to publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcosm",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "private": true,
   "description": "Flux with actions at center stage. Write optimistic updates, cancel requests, and track changes with ease.",
   "main": "microcosm.js",

--- a/src/history.js
+++ b/src/history.js
@@ -105,6 +105,8 @@ History.prototype = {
 
     this.archive()
 
+    this.invoke('update')
+
     this.invoke('release', action)
   },
 

--- a/test/unit/microcosm/release.test.js
+++ b/test/unit/microcosm/release.test.js
@@ -44,4 +44,27 @@ describe('Microcosm::release', function () {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
+  it('children have the latest state when their parents change', function() {
+    expect.assertions(2)
+
+    let step = n => n
+    let repo = new Microcosm({ maxHistory: Infinity })
+    let fork = repo.fork()
+
+    repo.addDomain('count', {
+      getInitialState() {
+        return 0
+      },
+      register () {
+        return { [step]: (a,b) => a + b }
+      }
+    })
+
+    repo.on('change', function () {
+      expect(repo.state.count).toBe(1)
+      expect(fork.state.count).toBe(repo.state.count)
+    })
+
+    repo.push(step, 1)
+  })
 })


### PR DESCRIPTION
This commit prevents a bug where children would not receive the latest
updates when their parents emitted a change event.

I believe this was introduced in 12.1.0.