### PR TITLE
Add history.wait() feature to wait for all outstanding actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+## 12.4.0
+
+- Added `repo.history.wait()` and `repo.history.then()` to allow tests
+  to wait for all outstanding actions to complete.
+- Added `repo.history` documentation.
+
+
 ## 12.3.1
+
 - Fix bug where Presenters weren't intercepting actions sent from
 child views.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@
 2. [Domains](api/domains.md)
 3. [Actions](api/actions.md)
 4. [Effects](api/effects.md)
-5. [Immutability Helpers](api/immutability-helpers.md)
+5. [History](api/history.md)
+6. [Immutability Helpers](api/immutability-helpers.md)
 
 ## Addons
 

--- a/docs/api/history.md
+++ b/docs/api/history.md
@@ -3,9 +3,10 @@
 1. [Overview](#overview)
 2. [API](#api)
 
-**Note: This is a work in progress document and feature. History has been a
-private API for a very long time. We're still working through the best
-public interface for working with Microcosm's action history.
+**Note: This is a work in progress document and feature. History has
+been a private API for a very long time. We're still working through
+the best public interface for working with Microcosm's action
+history.**
 
 ## Overview
 

--- a/docs/api/history.md
+++ b/docs/api/history.md
@@ -106,6 +106,15 @@ In the example above, actions `one` and `two` will be forgotten. The
 repo's history will reconcile, and it will be as if they never
 existed.
 
+This flips the `disabled` state of each action provided. By executing
+toggle a second time, these actions will be re-enabled:
+
+```
+// Actions disabled in the prior example
+repo.history.toggle([ one, two ])
+// `one` and `two` have been re-enabled
+```
+
 ### toArray()
 
 Return an array version of the active branch:

--- a/docs/api/history.md
+++ b/docs/api/history.md
@@ -1,0 +1,182 @@
+# History
+
+1. [Overview](#overview)
+2. [API](#api)
+
+**Note: This is a work in progress document and feature. History has been a
+private API for a very long time. We're still working through the best
+public interface for working with Microcosm's action history.
+
+## Overview
+
+All Microcosms have a history. This history keeps track of outstanding
+actions, working with a Microcosm to determine the next application
+state as actions move through different states.
+
+By default, Microcosm automatically disposes actions that are
+complete. However you can control how many actions Microcosm's history
+will hold on to by passing the `maxHistory` option:
+
+```javascript
+// Hold onto the last 10 actions
+let repo = new Microcosm({ maxHistory: 10 })
+
+// Or never forget anything
+let repo = new Microcosm({ maxHistory: Infinity })
+
+// Then push some actions
+repo.push(action)
+repo.push(action)
+repo.push(action)
+
+// Get actions out by using `repo.history.toArray()`
+let actions = repo.history.toArray() // [actionOne, actionTwo, actionThree]
+```
+
+### The data structure
+
+History stores actions as a tree, with a root and a head:
+
+```
+[root] - [one] - [two] - [three]
+```
+
+You can revert to a prior action by using `checkout(action)`:
+
+```javascript
+let repo = new Microcosm({ maxHistory: Infinity })
+
+let one = repo.push(action)
+let two = repo.push(action)
+
+repo.history.checkout(one)
+
+let three = repo.push(action)
+```
+
+In the example above, the following tree would be produced:
+
+```
+               |- [two]
+[root] - [one] +
+               |- [*three]
+```
+
+`three` is the active branch, marked with an asterisk. The active
+branch is used to determine state. Here, a Microcosm's state will be
+the result of dispatching `root`, `one`, and `three` to Domains.
+
+## API
+
+### checkout(action)
+
+Set the head of the tree to a target action. This has the effect
+of controlling time in a Microcosm's history:
+
+```javascript
+let repo = new Microcosm({ maxHistory: Infinity })
+
+let one = repo.push(action)
+let two = repo.push(action)
+
+repo.history.checkout(one)
+
+let three = repo.push(action)
+```
+
+The head of the history tree above is now three. Microcosm will
+calculate state by reconciling `root`, `one,` and `three`.
+
+
+### toggle([ ...actions ])
+
+Disable a group of actions:
+
+```
+let repo = new Microcosm({ maxHistory: Infinity })
+
+let one = repo.push(addUser)
+let two = repo.push(updateUser)
+
+repo.history.toggle([ one, two ])
+```
+
+In the example above, actions `one` and `two` will be forgotten. The
+repo's history will reconcile, and it will be as if they never
+existed.
+
+### toArray()
+
+Return an array version of the active branch:
+
+```javascript
+let repo = new Microcosm({ maxHistory: Infinity })
+
+let one = repo.push(action)
+let two = repo.push(action)
+
+repo.history.checkout(one)
+
+let three = repo.push(action)
+
+repo.toArray() // => [ root, one, three ]
+```
+
+### wait()
+
+Return a Promise that waits for all current actions to complete. If
+any action rejects, this promise will reject. **cancellation is
+ignored. Cancelling an action will not reject this promise.**
+
+```javascript
+let repo = new Microcosm({ maxHistory: Infinity })
+
+let one = repo.push(asyncAction)
+let two = repo.push(asyncAction)
+let three = repo.push(asyncAction)
+
+repo.wait().then(function () {
+  // Everything is done
+})
+```
+
+### then(resolve, reject)
+
+Allows for direct Promise interop with history. One common use case
+for this is to wait for all actions to complete before executing a
+test. For example, if we were to write a test with Jest:
+
+```javascript
+describe('An AJAX behavior', function() {
+
+  it('adds a user', async function () {
+    let repo = new MyMicrocosm({ maxHistory: Infinity })
+
+    repo.push(getUser, 1)
+    repo.push(getUser, 2)
+    repo.push(getUser, 3)
+
+    await repo.history
+
+    expect(repo.users.length).toEqual(3)
+  })
+
+})
+```
+
+### remove(action)
+
+Completely remove an action from history. This is a dangerous
+operation! Removed actions can never be re-inserted.
+
+```javascript
+let repo = new MyMicrocosm({ maxHistory: Infinity })
+
+let one = repo.push(action)
+let two = repo.push(action)
+let three = repo.push(action)
+
+repo.history.remove(two)
+
+repo.history.toArray() // [root, one, three]
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcosm",
-  "version": "12.3.1",
+  "version": "12.4.0",
   "private": true,
   "description": "Flux with actions at center stage. Write optimistic updates, cancel requests, and track changes with ease.",
   "main": "microcosm.js",

--- a/site/src/layouts/default.html
+++ b/site/src/layouts/default.html
@@ -46,6 +46,7 @@
             <li><a href="$base_url$/api/domains.html">Domains</a></li>
             <li><a href="$base_url$/api/actions.html">Actions</a></li>
             <li><a href="$base_url$/api/effects.html">Effects</a></li>
+            <li><a href="$base_url$/api/history.html">History</a></li>
             <li><a href="$base_url$/api/immutability-helpers.html">Immutability Helpers</a></li>
           </ul>
         </section>

--- a/test/unit/history/then.test.js
+++ b/test/unit/history/then.test.js
@@ -16,6 +16,8 @@ describe('History::then', function () {
       three.resolve()
     }, 10)
 
+    // This will fail if the promise returned from `history.then`
+    // rejects, it will only pass when the promise resolves.
     return history
   })
 

--- a/test/unit/history/then.test.js
+++ b/test/unit/history/then.test.js
@@ -1,0 +1,40 @@
+import History from '../../../src/history'
+
+describe('History::then', function () {
+  const action = n => n
+
+  it('allows direct interop with promises', function () {
+    const history = new History()
+
+    let one = history.append(action)
+    let two = history.append(action)
+    let three = history.append(action)
+
+    setTimeout(function() {
+      one.resolve()
+      two.resolve()
+      three.resolve()
+    }, 10)
+
+    return history
+  })
+
+  it('passes a failure callback', function () {
+    const history = new History()
+
+    let one = history.append(action)
+    let two = history.append(action)
+    let three = history.append(action)
+
+    setTimeout(function() {
+      one.resolve()
+      two.resolve()
+      three.reject('Error')
+    }, 10)
+
+    return history.then(null, function (error) {
+      expect(error).toEqual('Error')
+    })
+  })
+
+})

--- a/test/unit/history/wait.test.js
+++ b/test/unit/history/wait.test.js
@@ -52,6 +52,8 @@ describe('History::wait', function () {
       three.resolve('Wut')
     }, 10)
 
+    // This will fail if the promise returned from `wait()` rejects, and
+    // it will only pass when the promise resolves.
     return history.wait()
   })
 

--- a/test/unit/history/wait.test.js
+++ b/test/unit/history/wait.test.js
@@ -1,0 +1,58 @@
+import History from '../../../src/history'
+
+describe('History::wait', function () {
+  const action = n => n
+
+  it('resolves when every action completes successfull', function () {
+    const history = new History()
+
+    let one = history.append(action)
+    let two = history.append(action)
+    let three = history.append(action)
+
+    setTimeout(function() {
+      one.resolve()
+      two.resolve()
+      three.resolve()
+    }, 10)
+
+    return history.wait()
+  })
+
+  it('fails when an action rejects', async function () {
+    const history = new History(Infinity)
+
+    let one = history.append(action)
+    let two = history.append(action)
+    let three = history.append(action)
+
+    setTimeout(function() {
+      one.resolve()
+      two.resolve()
+      three.reject('Wut')
+    }, 10)
+
+    try {
+      await history.wait()
+    } catch (error) {
+      expect(error).toEqual('Wut')
+    }
+  })
+
+  it('ignores cancelled actions', function () {
+    const history = new History(Infinity)
+
+    let one = history.append(action)
+    let two = history.append(action)
+    let three = history.append(action)
+
+    setTimeout(function() {
+      one.resolve()
+      two.cancel()
+      three.resolve('Wut')
+    }, 10)
+
+    return history.wait()
+  })
+
+})


### PR DESCRIPTION
On one of our current projects, we have a bit of a hack to wait for all actions to complete before running a test. I want to more formally support that, and add some documentation around how it works. 

This commit adds promise interop for action history. This is useful for waiting for history to complete before doing some other type of work. It also adds documentation for history, which is somewhat unstable still, something we clarify in the doc.

With this PR, you can now do:

```javascript
describe('An AJAX behavior', function() {

  it('adds a user', async function () {
    let repo = new MyMicrocosm({ maxHistory: Infinity })

    repo.push(getUser, 1)
    repo.push(getUser, 2)
    repo.push(getUser, 3)

    await repo.history

    expect(repo.users.length).toEqual(3)
  })

})
```

I need way more infographics for this. Please help!

---

Related issues:
https://github.com/vigetlabs/microcosm/issues/232