### PR TITLE
Add strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - The first argument of `setup`, the options object passed when
   instantiating a Microcosm argument, will always be an object. There
   is no need to handle the null case for options.
+- Added a strict mode build of Microcosm that ships with development
+  assertions. See `installation.md` for more details
 
 ### Defaults
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,0 +1,77 @@
+# Installation
+
+1. [Up and running](#up-and-running)
+2. [Strict mode](#strict-mode)
+
+## Up and running
+
+The easiest way to grab Microcosm is
+through [npm](https://www.npmjs.com/package/microcosm):
+
+```bash
+npm install --save microcosm
+```
+
+From there, we recommend using a tool
+like [Webpack](https://webpack.js.org/) to bundle your code and pull
+in dependencies from `npm`.
+
+If you have never heard of Webpack,
+fantastic! Now's a great time to check it
+out. [Webpack's excellent getting started guide](https://webpack.js.org/guides/get-started/) covers
+everything you need to know before getting started.
+
+## Strict mode
+
+Microcosm ships with a "strict mode", this is a special version of
+Microcosm that includes development-only assertions. These help to
+avoid common mistakes and ensure correct usage of Microcosm
+APIs. **Assertions do not ship with the standard version of Microcosm.
+They are totally opt in.**
+
+Enable assertions by pointing to `microcosm/strict` in your application:
+
+```javascript
+import Microcosm from 'microcosm/strict/microcosm.js'
+```
+
+However, this is hardly ideal. We recommend using
+a
+[Webpack alias](https://webpack.js.org/configuration/resolve/#resolve-alias) to
+automatically point to the strict version of Microcosm whenever you
+import it:
+
+```javascript
+// webpack.config.js
+module.exports = {
+  // ...
+  resolve: {
+    alias: {
+      "microcosm$": "microcosm/strict/microcosm.js",
+      "microcosm/addons/$": "microcosm/strict/addons/",
+    }
+  }
+  // ...
+}
+```
+
+### How do I remove assertions in production?
+
+We recommend switching a Webpack alias between environments. Drawing
+from the prior example:
+
+```javascript
+// webpack.config.js
+var isProduction = process.env.NODE_ENV !== 'development'
+
+module.exports = {
+  // ...
+  resolve: {
+    alias: {
+      "microcosm$": isProduction ? 'microcosm' : "microcosm/strict/microcosm.js",
+      "microcosm/addons/$": isProduction ? 'microcosm/addons/' : "microcosm/strict/addons/",
+    }
+  }
+  // ...
+}
+```

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ const config = {
   ]
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.BABEL_ENV === 'production') {
   config.plugins.push(
     uglify({
       compress: {

--- a/site/src/layouts/default.html
+++ b/site/src/layouts/default.html
@@ -35,6 +35,7 @@
           <h4 class="sidebar__heading">Introduction</h4>
           <ul>
             <li><a href="$base_url$/guides/quickstart.html">Quickstart</a></li>
+            <li><a href="$base_url$/guides/installation.html">Installation</a></li>
             <li><a href="$base_url$/guides/architecture.html">Architecture</a></li>
             <li><a href="$base_url$/guides/contributing.html">Contributing</a></li>
           </ul>


### PR DESCRIPTION
This commit adds strict mode: a special bundle of Microcosm that
includes development-only assertions. It also adds an installation
guide for setting up strict mode with Webpack.

Fixes:
https://github.com/vigetlabs/microcosm/issues/280
