### PR TITLE
Generators define sequences of actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 12.6.0-beta
+
+- Actions may now create workflows of sequential actions using
+  generators. See `./docs/api/actions` for more information
+
 ## 12.5.0
 
 - Added a `defaults` static to Microcosm that passes default options

--- a/src/addons/jest-matchers.js
+++ b/src/addons/jest-matchers.js
@@ -51,7 +51,7 @@ expect.extend({
     let actual = get(repo.state, key)
 
     if (arguments.length > 2) {
-      pass = actual === value
+      pass = JSON.stringify(actual) === JSON.stringify(value)
     } else {
       pass = actual !== undefined
     }
@@ -62,8 +62,8 @@ expect.extend({
     return {
       pass: pass,
       message: () => {
-        return `Expected '${path}' in repo.state ${operator} be ${JSON.stringify(value)} ` +
-               `but it is ${actual}.`
+        return `Expected '${path}' in repo.state ${operator} be ${this.utils.printExpected(value)} ` +
+               `but it is ${this.utils.printReceived(actual)}.`
       }
     }
   }

--- a/test/unit/middleware/generator-middleware.test.js
+++ b/test/unit/middleware/generator-middleware.test.js
@@ -1,0 +1,94 @@
+import Microcosm from '../../../src/microcosm'
+
+describe('Generator Middleware', function () {
+
+  it('processes actions sequentially', function () {
+    expect.assertions(1)
+
+    let stepper = n => n + 1
+    let repo = new Microcosm()
+
+    function range (start, end) {
+      return function * (send) {
+        let value = start
+
+        while (value < end) {
+          value = yield send(stepper, value)
+        }
+      }
+    }
+
+    repo.push(range, 0, 3).onDone(result => {
+      expect(result).toEqual(3)
+    })
+  })
+
+  it('continues if yielding a non-action value', function () {
+    expect.assertions(1)
+
+    let repo = new Microcosm()
+    let step = n => n
+
+    function test () {
+      return function * (send) {
+        yield send(step, 1)
+        yield true
+      }
+    }
+
+    repo.push(test).onDone(result => {
+      expect(result).toEqual(true)
+    })
+  })
+
+  it('a rejected step halts the chain', function () {
+    expect.assertions(1)
+
+    let stepper = n => n + 1
+    let repo = new Microcosm()
+
+    let sequence = repo.push(function () {
+      return function * (send, repo) {
+        yield send(stepper, 0)
+        yield repo.append(stepper).reject('Failure')
+        yield send(stepper)
+      }
+    })
+
+    sequence.onDone(function () {
+      throw new Error('Sequence should not have completed')
+    })
+
+    sequence.onError(result => {
+      expect(result).toEqual('Failure')
+    })
+  })
+
+  it('a cancelled step halts the chain', function () {
+    expect.assertions(1)
+
+    let stepper = n => n + 1
+    let repo = new Microcosm()
+
+    let sequence = repo.push(function () {
+      return function * (send, repo) {
+        yield send(stepper, 0)
+        yield repo.append(stepper).cancel('Cancelled')
+        yield send(stepper)
+      }
+    })
+
+    sequence.onDone(function () {
+      throw new Error('Sequence should not have resolved')
+    })
+
+    sequence.onError(function () {
+      throw new Error('Sequence should not have rejected')
+    })
+
+    sequence.onCancel(result => {
+      expect(result).toEqual('Cancelled')
+    })
+  })
+
+})


### PR DESCRIPTION
Often times we need to dispatch multiple actions in sequential order. For example, what if we want to ask the user to confirm their action before deleting a record?

This can be accomplished by using a generator:

```javascript
function ask (message) {
  return action => {
    if (confirm(message)) {
      action.resolve()
    } else {
      action.reject()
    }
  }
}

function deleteUser (id) {
  return fetch.delete('/users/${id}').then(response => response.json())
}

function confirmAndDelete (user) {
  return function * (send) {
    yield send(ask, `Are you sure you want to delete ${user.name}?`)
    yield send(deleteUser, user.id)
  }
}
```

Each `yield` in the generator processes sequentially. A parent action is returned from `repo.push()` to represent the entire sequence. If any action is cancelled or rejected along the way, the parent action is rejected or cancelled with the same payload.

When all steps of the generator complete, the payload of the parent action will be the resolved payload of the final action.