### PR TITLE
Rework generator sequence

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -135,9 +135,9 @@ function deleteUser (id) {
 }
 
 function confirmAndDelete (user) {
-  return function * (send) {
-    yield send(ask, `Are you sure you want to delete ${user.name}?`)
-    yield send(deleteUser, user.id)
+  return function * (repo) {
+    yield repo.push(ask, `Are you sure you want to delete ${user.name}?`)
+    yield repo.push(deleteUser, user.id)
   }
 }
 ```

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -33,7 +33,7 @@ export default function coroutine (action, body, repo) {
   if (isGeneratorFn(body)) {
     action.open()
 
-    let iterator = body(repo.push.bind(repo), repo)
+    let iterator = body(repo)
 
     function step (payload) {
       let next = iterator.next(payload)

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -45,14 +45,13 @@ export default function coroutine (action, body, repo) {
       }
     }
 
-    function progress (value) {
-      if (value instanceof Action) {
-        value.onDone(step)
-        value.onCancel(action.cancel, action)
-        value.onError(action.reject, action)
-      } else {
-        step(value)
-      }
+    function progress (subAction) {
+      console.assert(subAction instanceof Action,
+                     `Iteration of generator expected an Action. Instead got ${subAction}`)
+
+      subAction.onDone(step)
+      subAction.onCancel(action.cancel, action)
+      subAction.onError(action.reject, action)
     }
 
     step()

--- a/test/unit/middleware/generator-middleware.test.js
+++ b/test/unit/middleware/generator-middleware.test.js
@@ -23,22 +23,20 @@ describe('Generator Middleware', function () {
     })
   })
 
-  it('continues if yielding a non-action value', function () {
+  it('throws if yielding a non-action value', function () {
     expect.assertions(1)
 
     let repo = new Microcosm()
     let step = n => n
 
     function test () {
-      return function * (send) {
+      return function * (repo) {
         yield repo.push(step, 1)
         yield true
       }
     }
 
-    repo.push(test).onDone(result => {
-      expect(result).toEqual(true)
-    })
+    expect(() => repo.push(test)).toThrow("Iteration of generator expected an Action")
   })
 
   it('a rejected step halts the chain', function () {
@@ -48,7 +46,7 @@ describe('Generator Middleware', function () {
     let repo = new Microcosm()
 
     let sequence = repo.push(function () {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(stepper, 0)
         yield repo.append(stepper).reject('Failure')
         yield repo.push(stepper)
@@ -71,7 +69,7 @@ describe('Generator Middleware', function () {
     let repo = new Microcosm()
 
     let sequence = repo.push(function () {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(stepper, 0)
         yield repo.append(stepper).cancel('Cancelled')
         yield repo.push(stepper)
@@ -102,7 +100,7 @@ describe('Generator Middleware', function () {
     }
 
     return repo.push(function () {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(sleep, 100)
         yield repo.push(sleep, 100)
       }
@@ -122,14 +120,14 @@ describe('Generator Middleware', function () {
     }
 
     function dream (time) {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)
       }
     }
 
     return repo.push(function () {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(dream, 100)
         yield repo.push(dream, 100)
       }
@@ -149,14 +147,14 @@ describe('Generator Middleware', function () {
     }
 
     function dream (time) {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)
       }
     }
 
     function dream100 () {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(dream, 100)
         yield repo.push(dream, 100)
       }
@@ -175,7 +173,7 @@ describe('Generator Middleware', function () {
     }
 
     function dream (time) {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)
@@ -205,7 +203,7 @@ describe('Generator Middleware', function () {
     }
 
     function dream (time) {
-      return function * (send, repo) {
+      return function * (repo) {
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)
         yield repo.push(sleep, time)

--- a/test/unit/middleware/generator-middleware.test.js
+++ b/test/unit/middleware/generator-middleware.test.js
@@ -185,37 +185,4 @@ describe('Generator Middleware', function () {
     await repo.history.wait()
   })
 
-  it('can push new actions during history.wait() while processing a generator', async function () {
-    let repo = new Microcosm()
-
-    repo.addDomain('test', {
-      register () {
-        return {
-          'test': n => n
-        }
-      }
-    })
-
-    function sleep (time) {
-      return action => {
-        setTimeout(() => action.resolve(true), time)
-      }
-    }
-
-    function dream (time) {
-      return function * (repo) {
-        yield repo.push(sleep, time)
-        yield repo.push(sleep, time)
-        yield repo.push(sleep, time)
-      }
-    }
-
-    repo.push(dream, 100)
-
-    await repo.history.wait()
-
-    repo.push('test', 1)
-    repo.push('test', 2)
-  })
-
 })


### PR DESCRIPTION
cc @efatsi 

It doesn't make sense to obscure the repo during an action generator sequence. Let's just pass it straight in:

```javascript
    function sleep (time) {
      return action => {
        setTimeout(() => action.resolve(true), time)
      }
    }

    function dream (time) {
      return function * (repo) {
        yield repo.push(sleep, time)
        yield repo.push(sleep, time)
        yield repo.push(sleep, time)
      }
    }

    repo.push(dream, 100)
```