### PR TITLE
Action status methods are autobound

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,16 +5,6 @@
     "react"
   ],
   "env": {
-    "development": {
-      "plugins": [
-        "babel-plugin-unassert"
-      ]
-    },
-    "production": {
-      "plugins": [
-        "babel-plugin-unassert"
-      ]
-    },
     "test": {
       "presets": [
         "es2015",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@
   change event, even if state didn't change.
 - The first argument of `repo.push` is passed into the `open` state of
   actions that return promises.
+- Action status changing methods are auto-bound, and will warn when a
+  completed action attempts to move into a new state (strict mode only)
+
+### Autobound action status methods
+
+Action status methods, like `action.resolve()`, or `action.reject()`
+are now auto-bound. This means that you can pass them directly into a
+callback, and the scope of the method will remain as the action. This
+is particularly useful when working with AJAX libraries. For example,
+when working with `superagent`:
+
+```javascript
+import superagent from 'superagent'
+
+function getPlanets () {
+  return action => {
+    let request = superagent.get('/planets')
+
+    request.on('request', action.open)
+    request.on('progress', action.update)
+
+    request.then(action.resolve, action.reject)
+  }
+}
+```
 
 ## 12.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,34 @@
 - Action status changing methods are auto-bound, and will warn when a
   completed action attempts to move into a new state (strict mode only)
 
-### Autobound action status methods
+### Auto-bound action status methods
 
-Action status methods, like `action.resolve()`, or `action.reject()`
-are auto-bound. This means that you can pass them directly into a
-callback, and the scope of the method will remain as the action. This
-is particularly useful when working with AJAX libraries. For example,
-when working with `superagent`:
+Action status methods like `action.resolve()` and `action.reject()`
+are auto-bound. They can be passed directly into a callback without
+needing to wrap them in an anonymous function.
+
+This is particularly useful when working with AJAX libraries. For
+example, when working with `superagent`:
+
+Instead of:
+
+```javascript
+import superagent from 'superagent'
+
+function getPlanets () {
+  return action => {
+    let request = superagent.get('/planets')
+
+    request.on('request', (data) => action.open(data))
+    request.on('progress', (data) => action.update(data))
+    request.on('abort', (data) => action.cancel(data))
+
+    request.then((data) => action.resolve(data), (error) => action.reject(error))
+  }
+}
+```
+
+You can do:
 
 ```javascript
 import superagent from 'superagent'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Autobound action status methods
 
 Action status methods, like `action.resolve()`, or `action.reject()`
-are now auto-bound. This means that you can pass them directly into a
+are auto-bound. This means that you can pass them directly into a
 callback, and the scope of the method will remain as the action. This
 is particularly useful when working with AJAX libraries. For example,
 when working with `superagent`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ function getPlanets () {
 
     request.on('request', action.open)
     request.on('progress', action.update)
+    request.on('abort', action.cancel)
 
     request.then(action.resolve, action.reject)
   }

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ build/package.json: package.json
 	@ node -p 'p=require("./package");p.private=p.scripts=p.jest=p.devDependencies=undefined;JSON.stringify(p,null,2)' > $@
 
 build/min/%.js: src/%.js $(SCRIPTS)
-	@ BABEL_ENV=production $(ROLLUP) -c rollup.config.js $< --output $@
+	@ MINIFY=true $(ROLLUP) -c rollup.config.js $< --output $@
 	@ echo $@
 	@ gzip -c $@ | wc -c | tr -d '[:space:]'
 	@ echo
 
 build/strict/%.js: src/%.js $(SCRIPTS)
-	@ BABEL_ENV=strict $(ROLLUP) -c rollup.config.js $< --output $@
+	@ STRICT=true $(ROLLUP) -c rollup.config.js $< --output $@
 
 build/%.js: src/%.js $(SCRIPTS)
 	@ $(ROLLUP) -c rollup.config.js $< --output $@

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -1,7 +1,7 @@
 # Actions
 
 1. [Overview](#overview)
-2. [Writing action creators](#writing-action-creators)
+2. [Writing Action Creators](#writing-action-creators)
 3. [Dispatching to Domains](#dispatching-to-domains)
 4. [How this works](#how-this-works)
 5. [API](#api)
@@ -158,6 +158,29 @@ is rejected or cancelled with the same payload.
 
 When all steps of the generator complete, the payload of the parent
 action will be the resolved payload of the final action.
+
+### Action status methods are auto-bound
+
+Action status methods, like `action.resolve()`, or `action.reject()`
+are auto-bound. This means that you can pass them directly into a
+callback and the scope of the method will remain as the action. This
+is particularly useful when working with AJAX libraries. For example,
+`superagent`:
+
+```javascript
+import superagent from 'superagent'
+
+function getPlanets () {
+  return action => {
+    let request = superagent.get('/planets')
+
+    request.on('request', action.open)
+    request.on('progress', action.update)
+
+    request.then(action.resolve, action.reject)
+  }
+}
+```
 
 ## Dispatching to Domains
 

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -198,11 +198,13 @@ const SolarSystem = {
 
   register() {
     return {
-      [getPlanet.open]      : this.setLoading,
-      [getPlanet.loading]   : this.setProgress,
-      [getPlanet.done]      : this.addPlanet,
-      [getPlanet.error]     : this.setError,
-      [getPlanet.cancelled] : this.setCancelled
+      [getPlanet]: {
+        open   : this.setLoading,
+        update : this.setProgress,
+        done   : this.addPlanet,
+        error  : this.setError,
+        cancel : this.setCancelled
+      }
     }
   }
 }

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -176,6 +176,7 @@ function getPlanets () {
 
     request.on('request', action.open)
     request.on('progress', action.update)
+    request.on('abort', action.cancel)
 
     request.then(action.resolve, action.reject)
   }

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -161,11 +161,12 @@ action will be the resolved payload of the final action.
 
 ### Action status methods are auto-bound
 
-Action status methods, like `action.resolve()`, or `action.reject()`
-are auto-bound. This means that you can pass them directly into a
-callback and the scope of the method will remain as the action. This
-is particularly useful when working with AJAX libraries. For example,
-`superagent`:
+Action status methods like `action.resolve()` and `action.reject()`
+are auto-bound. They can be passed directly into a callback without
+needing to wrap them in an anonymous function.
+
+This is particularly useful when working with AJAX libraries. For
+example, when working with `superagent`:
 
 ```javascript
 import superagent from 'superagent'

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     ]
   },
   "dependencies": {
-    "form-serialize": "0.7.1"
+    "form-serialize": "0.7.1",
+    "rollup-plugin-strip": "^1.1.1"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",
-    "babel-plugin-unassert": "^2.1.2",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import babel from 'rollup-plugin-babel'
+import strip from 'rollup-plugin-strip'
 import uglify from 'rollup-plugin-uglify'
 import nodeResolve from 'rollup-plugin-node-resolve'
 import path from 'path'
@@ -19,7 +20,17 @@ const config = {
   ]
 }
 
-if (process.env.BABEL_ENV === 'production') {
+if (process.env.STRICT !== 'true') {
+  config.plugins.push(
+    strip({
+      debugger: true,
+      functions: ['console.*'],
+      sourceMap: true
+    })
+  )
+}
+
+if (process.env.MINIFY) {
   config.plugins.push(
     uglify({
       compress: {

--- a/src/action.js
+++ b/src/action.js
@@ -232,7 +232,7 @@ inherit(Action, Emitter, {
  */
 function createCompleteWarning (action, method) {
   return function () {
-    console.assert(false, `Action ${action.command.name} is already in ` +
+    console.assert(false, `Action "${action.command.name || action.type}" is already in ` +
                    `the ${action.status} state, it will not change. Calling ` +
                    `${method} will not change it.`)
   }

--- a/src/action.js
+++ b/src/action.js
@@ -232,9 +232,8 @@ inherit(Action, Emitter, {
  */
 function createCompleteWarning (action, method) {
   return function () {
-    console.assert(false, `Action "${action.command.name || action.type}" is already in ` +
-                   `the ${action.status} state, it will not change. Calling ` +
-                   `${method} will not change it.`)
+    console.warn(`Action "${action.command.name || action.type}" is already in ` +
+                 `the ${action.status} state. Calling ${method}() will not change it.`)
   }
 }
 

--- a/test/unit/action/autobinding.test.js
+++ b/test/unit/action/autobinding.test.js
@@ -1,0 +1,26 @@
+import Action from '../../../src/action'
+
+const identity = n => n
+
+describe('Action autobinding', function () {
+
+  let states = [ 'open', 'update', 'resolve', 'reject', 'cancel' ]
+
+  states.forEach(function (state) {
+
+    it(`${state} is autobound`, function () {
+      const action = new Action(identity)
+
+      function passByValue (callback) {
+        callback(true)
+      }
+
+      passByValue(action[state])
+
+      expect(action.status).toEqual(state)
+      expect(action.payload).toEqual(true)
+    })
+
+  })
+
+})

--- a/test/unit/action/cancelled.test.js
+++ b/test/unit/action/cancelled.test.js
@@ -38,7 +38,8 @@ describe('Action cancelled state', function () {
     action.onCancel(callback)
 
     action.cancel()
-    action.cancel()
+
+    action._emit('cancel')
 
     expect(callback).toHaveBeenCalledTimes(1)
   })

--- a/test/unit/action/complete.test.js
+++ b/test/unit/action/complete.test.js
@@ -31,15 +31,17 @@ describe('Action complete state', function () {
 
   it('will not change states if already complete', function () {
     const action = new Action(identity)
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.cancel()
+    action.resolve()
 
-    expect(function () {
-      action.resolve()
-    }).toThrow(/Action "identity" is already in the cancel state/)
+    expect(spy).toHaveBeenCalledWith('Action "identity" is already in the cancel state. Calling resolve() will not change it.')
 
     expect(action.is('cancelled')).toBe(true)
     expect(action.is('done')).toBe(false)
+
+    spy.mockRestore()
   })
 
 })

--- a/test/unit/action/complete.test.js
+++ b/test/unit/action/complete.test.js
@@ -36,7 +36,7 @@ describe('Action complete state', function () {
 
     expect(function () {
       action.resolve()
-    }).toThrow(/Action identity is already in the cancel state/)
+    }).toThrow(/Action "identity" is already in the cancel state/)
 
     expect(action.is('cancelled')).toBe(true)
     expect(action.is('done')).toBe(false)

--- a/test/unit/action/complete.test.js
+++ b/test/unit/action/complete.test.js
@@ -29,11 +29,14 @@ describe('Action complete state', function () {
     expect(action.complete).toBe(true)
   })
 
-  it('will not change states if already disposed', function () {
+  it('will not change states if already complete', function () {
     const action = new Action(identity)
 
     action.cancel()
-    action.resolve()
+
+    expect(function () {
+      action.resolve()
+    }).toThrow(/Action identity is already in the cancel state/)
 
     expect(action.is('cancelled')).toBe(true)
     expect(action.is('done')).toBe(false)

--- a/test/unit/action/done.test.js
+++ b/test/unit/action/done.test.js
@@ -52,7 +52,7 @@ describe('Action done state', function () {
 
     expect(function () {
       action.resolve(true)
-    }).toThrow(/Action identity is already in the reject state/)
+    }).toThrow(/Action "identity" is already in the reject state/)
 
     expect(action).toHaveStatus('error')
     expect(action).not.toHaveStatus('done')

--- a/test/unit/action/done.test.js
+++ b/test/unit/action/done.test.js
@@ -49,7 +49,10 @@ describe('Action done state', function () {
     const action = repo.append(identity)
 
     action.reject(false)
-    action.resolve(true)
+
+    expect(function () {
+      action.resolve(true)
+    }).toThrow(/Action identity is already in the reject state/)
 
     expect(action).toHaveStatus('error')
     expect(action).not.toHaveStatus('done')

--- a/test/unit/action/done.test.js
+++ b/test/unit/action/done.test.js
@@ -47,15 +47,17 @@ describe('Action done state', function () {
   it('actions can not be resolved after rejected', function () {
     const repo = new Microcosm()
     const action = repo.append(identity)
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.reject(false)
+    action.resolve()
 
-    expect(function () {
-      action.resolve(true)
-    }).toThrow(/Action "identity" is already in the reject state/)
+    expect(spy).toHaveBeenCalledWith('Action "identity" is already in the reject state. Calling resolve() will not change it.')
 
     expect(action).toHaveStatus('error')
     expect(action).not.toHaveStatus('done')
+
+    spy.mockRestore()
   })
 
   it('aliases the done type with resolve', function () {

--- a/test/unit/action/error.test.js
+++ b/test/unit/action/error.test.js
@@ -52,7 +52,7 @@ describe('Action error state', function () {
 
     expect(function () {
       action.reject()
-    }).toThrow(/Action identity is already in the resolve state/)
+    }).toThrow(/Action "identity" is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/error.test.js
+++ b/test/unit/action/error.test.js
@@ -46,13 +46,13 @@ describe('Action error state', function () {
   it('does not trigger an error event if it is complete', function () {
     const action = new Action(identity)
     const spy = jest.fn()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('error', spy)
     action.resolve()
+    action.reject()
 
-    expect(function () {
-      action.reject()
-    }).toThrow(/Action "identity" is already in the resolve state/)
+    expect(warn).toHaveBeenCalledWith('Action "identity" is already in the resolve state. Calling reject() will not change it.')
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/error.test.js
+++ b/test/unit/action/error.test.js
@@ -49,7 +49,10 @@ describe('Action error state', function () {
 
     action.on('error', spy)
     action.resolve()
-    action.reject()
+
+    expect(function () {
+      action.reject()
+    }).toThrow(/Action identity is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/open.test.js
+++ b/test/unit/action/open.test.js
@@ -38,7 +38,10 @@ describe('Action open state', function () {
 
     action.on('open', spy)
     action.resolve()
-    action.open()
+
+    expect(function () {
+      action.open()
+    }).toThrow(/Action identity is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/open.test.js
+++ b/test/unit/action/open.test.js
@@ -35,13 +35,13 @@ describe('Action open state', function () {
   it('does not trigger an open event if it is complete', function () {
     const action = new Action(identity)
     const spy = jest.fn()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('open', spy)
     action.resolve()
+    action.open()
 
-    expect(function () {
-      action.open()
-    }).toThrow(/Action "identity" is already in the resolve state/)
+    expect(warn).toHaveBeenCalledWith('Action "identity" is already in the resolve state. Calling open() will not change it.')
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/open.test.js
+++ b/test/unit/action/open.test.js
@@ -41,7 +41,7 @@ describe('Action open state', function () {
 
     expect(function () {
       action.open()
-    }).toThrow(/Action identity is already in the resolve state/)
+    }).toThrow(/Action "identity" is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/update.test.js
+++ b/test/unit/action/update.test.js
@@ -62,7 +62,7 @@ describe('Action update state', function () {
 
     expect(function () {
       action.update()
-    }).toThrow(/Action identity is already in the resolve state/)
+    }).toThrow(/Action "identity" is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/update.test.js
+++ b/test/unit/action/update.test.js
@@ -56,13 +56,13 @@ describe('Action update state', function () {
   it('does not trigger an update event if it is complete', function () {
     const action = new Action(identity)
     const spy = jest.fn()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('update', spy)
     action.resolve()
+    action.update()
 
-    expect(function () {
-      action.update()
-    }).toThrow(/Action "identity" is already in the resolve state/)
+    expect(warn).toHaveBeenCalledWith('Action "identity" is already in the resolve state. Calling update() will not change it.')
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/update.test.js
+++ b/test/unit/action/update.test.js
@@ -59,7 +59,10 @@ describe('Action update state', function () {
 
     action.on('update', spy)
     action.resolve()
-    action.update()
+
+    expect(function () {
+      action.update()
+    }).toThrow(/Action identity is already in the resolve state/)
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,10 +774,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-unassert@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-unassert/-/babel-plugin-unassert-2.1.2.tgz#a1ea61811726db747079443ec1b15c4b06c6b944"
-
 babel-polyfill@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
@@ -3605,6 +3601,12 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
+magic-string@^0.15.0:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.15.2.tgz#0681d7388741bbc3addaa65060992624c6c09e9c"
+  dependencies:
+    vlq "^0.2.1"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -4675,13 +4677,22 @@ rollup-plugin-node-resolve@^3.0.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-strip@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-strip/-/rollup-plugin-strip-1.1.1.tgz#b965d9caa5971d626ed1b703ee73d3421e3fefd1"
+  dependencies:
+    acorn "^3.1.0"
+    estree-walker "^0.2.1"
+    magic-string "^0.15.0"
+    rollup-pluginutils "^1.3.1"
+
 rollup-plugin-uglify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-1.0.1.tgz#11d0b0c8bcd2d07e6908f74fd16b0152390b922a"
   dependencies:
     uglify-js "^2.6.1"
 
-rollup-pluginutils@^1.5.0:
+rollup-pluginutils@^1.3.1, rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:


### PR DESCRIPTION
Action status methods, like `action.resolve()`, or `action.reject()` are now auto-bound. This means that you can pass them directly into a callback, and the scope of the method will remain as the action. 

This is particularly useful when working with AJAX libraries. For example, when working with `superagent`:

```javascript
import superagent from 'superagent'

function getPlanets () {
  return action => {
    let request = superagent.get('/planets')

    request.on('request', action.open)
    request.on('progress', action.update)

    request.then(action.resolve, action.reject)
  }
}
```

I struggled with adding this for a long time. Auto-binding generally increases memory usage and adds extra instantiation overhead. However, using a getters to lazy-generate the functions seems to do the trick. 

I also added a strict-mode warning for when you try to complete an action that has already finished:

<img width="663" alt="screen shot 2017-04-14 at 7 56 16 am" src="https://cloud.githubusercontent.com/assets/590904/25042660/dac5deda-20e7-11e7-8450-b983601de929.png">

Related issues:
https://github.com/vigetlabs/microcosm/issues/144