### PR TITLE
Handle spaces in key paths, increase key path test coverage

### DIFF
--- a/src/key-path.js
+++ b/src/key-path.js
@@ -25,7 +25,7 @@ export function castPath (value) {
     return []
   }
 
-  return isString(value) ? value.split(KEY_DELIMETER) : [value]
+  return isString(value) ? value.trim().split(KEY_DELIMETER) : [value]
 }
 
 /**

--- a/test/unit/key-path/get-key-paths.test.js
+++ b/test/unit/key-path/get-key-paths.test.js
@@ -1,0 +1,52 @@
+import {
+  getKeyPaths
+} from '../../../src/key-path'
+
+describe('getKeyPaths', function () {
+
+  it('removes leading spaces between paths', function () {
+    let path = getKeyPaths('foo, bar')
+
+    expect(path.length).toBe(2)
+
+    expect(path[0]).toEqual(['foo'])
+    expect(path[1]).toEqual(['bar'])
+  })
+
+  it('removes trailing spaces between paths', function () {
+    let path = getKeyPaths('foo ,bar')
+
+    expect(path.length).toBe(2)
+
+    expect(path[0]).toEqual(['foo'])
+    expect(path[1]).toEqual(['bar'])
+  })
+
+  it('removes spaces at the beginning of a path', function () {
+    let path = getKeyPaths(' foo,bar')
+
+    expect(path.length).toBe(2)
+
+    expect(path[0]).toEqual(['foo'])
+    expect(path[1]).toEqual(['bar'])
+  })
+
+  it('removes spaces at the end of a path', function () {
+    let path = getKeyPaths('foo,bar ')
+
+    expect(path.length).toBe(2)
+
+    expect(path[0]).toEqual(['foo'])
+    expect(path[1]).toEqual(['bar'])
+  })
+
+  it('does not remove space between words', function () {
+    let path = getKeyPaths('foo, b ar')
+
+    expect(path.length).toBe(2)
+
+    expect(path[0]).toEqual(['foo'])
+    expect(path[1]).toEqual(['b ar'])
+  })
+
+})


### PR DESCRIPTION
Pretty cut and dry. I'm working on some stuff that uses key paths and I noticed that spaces aren't allowed. This PR allows for change subscriptions like:

```javascript
repo.on('lists, items', callback)
// or
repo.on('lists,items', callback)
```

Not a new feature, it's just natural to add a space after a comma, so let's make sure we cover it.