### PR TITLE
Presenter getModel callbacks support anything that implements call

### DIFF
--- a/src/addons/presenter.js
+++ b/src/addons/presenter.js
@@ -252,7 +252,7 @@ class PresenterMediator extends React.PureComponent {
     for (var key in model) {
       var entry = model[key]
 
-      if (typeof entry === 'function') {
+      if (entry && typeof entry.call === 'function') {
         this.propMap[key] = entry
         next[key] = entry.call(this.presenter, data, this.repo)
       } else {

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -343,6 +343,26 @@ describe('::getModel', function() {
       expect(spy).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('invoking model callbacks', function() {
+    it('supports any callable value', function() {
+      let callable = {
+        call: jest.fn()
+      }
+
+      class MyPresenter extends Presenter {
+        getModel() {
+          return {
+            test: callable
+          }
+        }
+      }
+
+      mount(<MyPresenter />)
+
+      expect(callable.call).toHaveBeenCalled()
+    })
+  })
 })
 
 describe('::setup', function() {


### PR DESCRIPTION
Any `getModel` value that implements `call` will be invoked just like a function. This lets you do neat stuff like this:

```javascript
import Presenter from 'microcosm/addons/presenter'
import { get } from 'microcosm'
import { getUsers } from 'actions/users'

class UsersQuery {
  constructor () {
    this.action = null
  }

  call (source, state, repo) {
    // Fetch user records if we don't already have them
    if (!this.action) {
      this.action = repo.push(getUsers)
    }

    return get(state, 'users')
  }
}

class UsersPresenter extends Presenter {
  getModel () {
    return {
      users: new UsersQuery()
    }
  }
}
```

Which is pretty neat. This allows us to work on an abstraction for querying data, and possibly automatically fetching it.
