### PR TITLE
Adds repo.all for parallel actions. Sugar in yield action format.

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -163,6 +163,26 @@ is rejected or cancelled with the same payload.
 When all steps of the generator complete, the payload of the parent
 action will be the resolved payload of the final action.
 
+#### Yielding Actions in Parallel
+
+By yielding an array of actions, you can wait for multiple actions to
+complete before continuing:
+
+```javascript
+function getUser (id) {
+  return fetch(`/users/${id}`)
+}
+
+function getUsers (ids) {
+  return function * (repo) {
+    yield ids.map(id => repo.push(getUser, id))
+  }
+}
+```
+
+If all actions resolve or cancel, the generator sequence
+continues.
+
 ### Action status methods are auto-bound
 
 Action status methods like `action.resolve()` and `action.reject()`

--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -329,6 +329,23 @@ fork.addDomain('page', PaginatedPeople)
 fork.push(getPeople)
 ```
 
+### `all([...actions])`
+
+Create a new "group" action bound to the resolution of a list of
+actions. If all actions resolve or cancel, the group action will
+resolve. If any action is rejected, the group action fails:
+
+```javascript
+let group = repo.all([
+  repo.push(actionOne),
+  repo.push(actionTwo)
+])
+
+group.onDone(function () {
+  console.log('hurrah!')
+})
+```
+
 ### `Microcosm.defaults`
 
 Specifies default options a Microcosm is instantiated with. This

--- a/docs/api/microcosm.md
+++ b/docs/api/microcosm.md
@@ -329,14 +329,14 @@ fork.addDomain('page', PaginatedPeople)
 fork.push(getPeople)
 ```
 
-### `all([...actions])`
+### `parallel([...actions])`
 
 Create a new "group" action bound to the resolution of a list of
 actions. If all actions resolve or cancel, the group action will
 resolve. If any action is rejected, the group action fails:
 
 ```javascript
-let group = repo.all([
+let group = repo.parallel([
   repo.push(actionOne),
   repo.push(actionTwo)
 ])

--- a/src/action.js
+++ b/src/action.js
@@ -163,7 +163,7 @@ class Action extends Emitter {
   link(actions) {
     let outstanding = actions.length
 
-    const onDone = () => {
+    const onResolve = () => {
       outstanding -= 1
 
       if (outstanding <= 0) {
@@ -172,8 +172,8 @@ class Action extends Emitter {
     }
 
     actions.forEach(action => {
-      action.onDone(onDone)
-      action.onCancel(onDone)
+      action.onDone(onResolve)
+      action.onCancel(onResolve)
       action.onError(this.reject)
     })
 

--- a/src/action.js
+++ b/src/action.js
@@ -155,6 +155,32 @@ class Action extends Emitter {
   }
 
   /**
+   * Set up an action such that it depends on the result of another
+   * series of actions.
+   * @param {Array.<Action>} actions
+   * @return {this}
+   */
+  link(actions) {
+    let outstanding = actions.length
+
+    const onDone = () => {
+      outstanding -= 1
+
+      if (outstanding <= 0) {
+        this.resolve()
+      }
+    }
+
+    actions.forEach(action => {
+      action.onDone(onDone)
+      action.onCancel(onDone)
+      action.onError(this.reject)
+    })
+
+    return this
+  }
+
+  /**
    * @param {?Function} pass
    * @param {Function} [fail]
    * @returns {Promise}

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -22,6 +22,10 @@ function processGenerator(action, body, repo) {
   }
 
   function progress(subAction) {
+    if (Array.isArray(subAction)) {
+      subAction = repo.all(subAction)
+    }
+
     console.assert(
       subAction instanceof Action,
       `Iteration of generator expected an Action. Instead got ${subAction}`

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -23,7 +23,7 @@ function processGenerator(action, body, repo) {
 
   function progress(subAction) {
     if (Array.isArray(subAction)) {
-      subAction = repo.all(subAction)
+      subAction = repo.parallel(subAction)
     }
 
     console.assert(

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -369,7 +369,7 @@ class Microcosm extends Emitter {
     this.removeAllListeners()
   }
 
-  all(actions) {
+  parallel(actions) {
     return this.append('GROUP').link(actions)
   }
 }

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -368,6 +368,10 @@ class Microcosm extends Emitter {
     // Remove all listeners
     this.removeAllListeners()
   }
+
+  all(actions) {
+    return this.append('GROUP').link(actions)
+  }
 }
 
 export default Microcosm


### PR DESCRIPTION
This commit adds the ability to batch together a group of actions under a parent "group" action. If all of the actions complete or cancel, the group resolves. Otherwise the action is categorically rejected.

This surfaces itself through a new Microcosm method: `repo.all([...actions])`: 

```javascript
let group = repo.all([
  repo.push(actionOne),
  repo.push(actionTwo)
])

group.onDone(function () {
  console.log('hurrah!')
})
```

Additionally, generator actions can yield an array:

```javascript
function fetchUsers(usersList) {
  return function*(repo) {
    let requests = usersList.map(repo.prepare(fetchUser))

    yield requests
  }
}
```

**What kind of change does this PR introduce?** 

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Related issues:**

- https://github.com/vigetlabs/microcosm/issues/229
