### PR TITLE
Microcosms can be register to actions

### DIFF
--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -10,10 +10,19 @@ class DomainEngine {
   constructor(repo) {
     this.registry = {}
     this.repo = repo
-    this.domains = [[[], this.repo]]
+    this.domains = []
 
     // All realms contain a meta domain for basic Microcosm operations
     this.add([], MetaDomain)
+
+    // Microcosms can register actions
+    this.addRepo(repo)
+  }
+
+  addRepo(repo) {
+    if (typeof repo.register !== 'undefined') {
+      this.domains.push([[], repo])
+    }
   }
 
   getHandlers({ command, status }) {

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -94,7 +94,7 @@ class Microcosm extends Emitter {
 
     this.parent = options.parent
 
-    this.initial = this.parent ? this.parent.initial : {}
+    this.initial = this.parent ? this.parent.initial : this.getInitialState()
     this.state = this.parent ? this.parent.state : this.initial
 
     this.history = this.parent ? this.parent.history : new History(options)
@@ -173,7 +173,7 @@ class Microcosm extends Emitter {
    * Generates the starting state for a Microcosm instance. This is the result of dispatching `getInitialState` to all domains. It is pure; calling this function will not update state.
    */
   getInitialState() {
-    return this.initial
+    return this.initial == null ? {} : this.initial
   }
 
   recall(action, fallback) {
@@ -371,6 +371,10 @@ class Microcosm extends Emitter {
 
   parallel(actions) {
     return this.append('GROUP').link(actions)
+  }
+
+  register() {
+    return {}
   }
 }
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -372,10 +372,6 @@ class Microcosm extends Emitter {
   parallel(actions) {
     return this.append('GROUP').link(actions)
   }
-
-  register() {
-    return {}
-  }
 }
 
 export default Microcosm

--- a/test/addons/presenter.test.js
+++ b/test/addons/presenter.test.js
@@ -9,12 +9,8 @@ const View = withSend(function({ send }) {
 })
 
 class Repo extends Microcosm {
-  setup() {
-    this.addDomain('color', {
-      getInitialState() {
-        return 'yellow'
-      }
-    })
+  getInitialState() {
+    return { color: 'yellow' }
   }
 }
 

--- a/test/unit/microcosm/patch.test.js
+++ b/test/unit/microcosm/patch.test.js
@@ -11,6 +11,20 @@ describe('Microcosm::patch', function() {
     expect(repo).not.toHaveState('shapes')
   })
 
+  it('allows patching state for domains that operate on the root', function() {
+    const repo = new Microcosm()
+
+    repo.addDomain('', {
+      getInitialState() {
+        return { shapes: [] }
+      }
+    })
+
+    repo.patch({ shapes: ['square', 'triangle', 'circle'] })
+
+    expect(repo).toHaveState('shapes', ['square', 'triangle', 'circle'])
+  })
+
   it('raises if there is a JSON parse error deserialization fails', function() {
     const repo = new Microcosm()
 

--- a/test/unit/microcosm/register.test.js
+++ b/test/unit/microcosm/register.test.js
@@ -1,0 +1,30 @@
+import Microcosm, { update } from '../../../src/microcosm'
+
+describe('Microcosm::register', function() {
+  it('a Microcosm can register to actiosn', function() {
+    const ADD = 'ADD'
+
+    class Repo extends Microcosm {
+      getInitialState() {
+        return { count: 0 }
+      }
+
+      add(state, n) {
+        return update(state, 'count', value => value + n)
+      }
+
+      register() {
+        return {
+          [ADD]: this.add
+        }
+      }
+    }
+
+    let repo = new Repo()
+
+    repo.push(ADD, 2)
+    repo.push(ADD, 2)
+
+    expect(repo).toHaveState('count', 4)
+  })
+})


### PR DESCRIPTION
Microcosms can now declare a custom register and getInitialState method. In this way, they behave exactly like domains.

This does not allow Microcosms to be added as domains to other Microcosms. That will require some work. This is intended to make it easier to introduce Microcosm, and for concise examples.

```javascript
const ADD = 'ADD'

class Repo extends Microcosm {
  getInitialState() {
    return { count: 0 }
  }

  add(state, n) {
    return update(state, 'count', value => value + n)
  }

  register() {
    return {
      [ADD]: this.add
    }
  }
}

let repo = new Repo()

repo.push(ADD, 2)
repo.push(ADD, 2)

expect(repo).toHaveState('count', 4)
```

---

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Does this PR fulfill these requirements:**

- [x] All tests are passing
- [x] Commits reference open issues