### PR TITLE
Do not warn in strict mode when changing a completed action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   the same behavior as `repo.parallel`
 - `Presenter::getModel` assignments
   accept [Observables](https://github.com/tc39/proposal-observable).
+- Do not warn in strict mode when attempting to change a complete
+  action. This allows for use cases like, "Cancel this action, but
+  only if it hasn't finished yet."
 
 ## 12.8.0
 

--- a/test/unit/action/complete.test.js
+++ b/test/unit/action/complete.test.js
@@ -29,18 +29,11 @@ describe('Action complete state', function() {
 
   it('will not change states if already complete', function() {
     const action = new Action(identity)
-    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.cancel()
     action.resolve()
 
-    expect(spy).toHaveBeenCalledWith(
-      'Action "identity" is already in the cancel state. Calling resolve() will not change it.'
-    )
-
     expect(action.is('cancelled')).toBe(true)
     expect(action.is('done')).toBe(false)
-
-    spy.mockRestore()
   })
 })

--- a/test/unit/action/done.test.js
+++ b/test/unit/action/done.test.js
@@ -46,19 +46,12 @@ describe('Action done state', function() {
   it('actions can not be resolved after rejected', function() {
     const repo = new Microcosm()
     const action = repo.append(identity)
-    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.reject(false)
     action.resolve()
 
-    expect(spy).toHaveBeenCalledWith(
-      'Action "identity" is already in the reject state. Calling resolve() will not change it.'
-    )
-
     expect(action).toHaveStatus('error')
     expect(action).not.toHaveStatus('done')
-
-    spy.mockRestore()
   })
 
   it('aliases the done type with resolve', function() {

--- a/test/unit/action/error.test.js
+++ b/test/unit/action/error.test.js
@@ -44,15 +44,10 @@ describe('Action error state', function() {
   it('does not trigger an error event if it is complete', function() {
     const action = new Action(identity)
     const spy = jest.fn()
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('error', spy)
     action.resolve()
     action.reject()
-
-    expect(warn).toHaveBeenCalledWith(
-      'Action "identity" is already in the resolve state. Calling reject() will not change it.'
-    )
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/open.test.js
+++ b/test/unit/action/open.test.js
@@ -33,15 +33,10 @@ describe('Action open state', function() {
   it('does not trigger an open event if it is complete', function() {
     const action = new Action(identity)
     const spy = jest.fn()
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('open', spy)
     action.resolve()
     action.open()
-
-    expect(warn).toHaveBeenCalledWith(
-      'Action "identity" is already in the resolve state. Calling open() will not change it.'
-    )
 
     expect(spy).not.toHaveBeenCalled()
   })

--- a/test/unit/action/update.test.js
+++ b/test/unit/action/update.test.js
@@ -55,15 +55,10 @@ describe('Action update state', function() {
   it('does not trigger an update event if it is complete', function() {
     const action = new Action(identity)
     const spy = jest.fn()
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     action.on('update', spy)
     action.resolve()
     action.update()
-
-    expect(warn).toHaveBeenCalledWith(
-      'Action "identity" is already in the resolve state. Calling update() will not change it.'
-    )
 
     expect(spy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
This allows for use cases like, "Cancel this action, but only if it hasn't finished yet.":

```javascript
class PlanetsList extends Presenter {
  getModel () {
    return {
      planets: state => state.planets
    }
  }
  setup (repo) {
    this.action = repo.push(getPlanets)
  }
  teardown () {
    // We no longer care about this
    this.action.cancel()
  }
  // ...
}
```

---

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Does this PR fulfill these requirements:**

- [x] All tests are passing
- [x] Commits reference open issues