### PR TITLE
Implement toJSON for Action and History

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -290,6 +290,16 @@ class Action extends Emitter {
       }
     }
   }
+
+  toJSON() {
+    return {
+      id: this.id,
+      status: this.status,
+      type: this.type,
+      payload: this.payload,
+      children: this.children
+    }
+  }
 }
 
 /**

--- a/src/history.js
+++ b/src/history.js
@@ -345,6 +345,18 @@ class History extends Emitter {
       cursor = cursor.parent
     }
   }
+
+  /**
+   * Serialize history into JSON data
+   */
+  toJSON() {
+    return {
+      head: this.head.id,
+      root: this.root.id,
+      size: this.size,
+      tree: this.root
+    }
+  }
 }
 
 export default History

--- a/test/unit/history/__snapshots__/toJSON.test.js.snap
+++ b/test/unit/history/__snapshots__/toJSON.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`History::toJSON serializes the tree of actions 1`] = `
+Object {
+  "head": 12,
+  "root": 10,
+  "size": 2,
+  "tree": Object {
+    "children": Array [
+      Object {
+        "children": Array [],
+        "id": 12,
+        "payload": true,
+        "status": "resolve",
+        "type": "action.5",
+      },
+    ],
+    "id": 10,
+    "payload": undefined,
+    "status": "resolve",
+    "type": "$start.3",
+  },
+}
+`;

--- a/test/unit/history/toJSON.test.js
+++ b/test/unit/history/toJSON.test.js
@@ -1,0 +1,44 @@
+import History from '../../../src/history'
+
+describe('History::toJSON', function() {
+  const action = n => n
+
+  it('includes the size of the tree', function() {
+    const history = new History({ maxHistory: Infinity })
+
+    history.append(action).resolve()
+    history.append(action).resolve()
+
+    let json = JSON.parse(JSON.stringify(history))
+
+    expect(json.size).toEqual(3)
+  })
+
+  it('includes an id reference to the head', function() {
+    const history = new History({ maxHistory: Infinity })
+
+    history.append(action).resolve()
+
+    let json = JSON.parse(JSON.stringify(history))
+
+    expect(json.head).toEqual(history.head.id)
+  })
+
+  it('includes an id reference to the root', function() {
+    const history = new History({ maxHistory: Infinity })
+
+    history.append(action).resolve()
+
+    let json = JSON.parse(JSON.stringify(history))
+
+    expect(json.root).toEqual(history.root.id)
+  })
+
+  it('serializes the tree of actions', function() {
+    const history = new History({ maxHistory: Infinity })
+
+    history.append(action).resolve(true)
+
+    expect(history).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
This allows serialization of history for developer tools. This lets you do:

```javascript
JSON.stringify(repo.history) 
// { size: 3, root: { id: 0, status: 'resolved', payload: true, children: [...] }
```

This is for:

https://github.com/vigetlabs/microcosm-devtools