### PR TITLE
Fix bugs in history.remove

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -179,22 +179,29 @@ class History extends Emitter {
       return
     }
 
-    let next = action.next
+    // cache linking references and activeness
     let parent = action.parent
+    let next = action.next
+    let wasActive = this.isActive(action)
 
     this.clean(action)
 
+    // if there are no more actions left, we're done
     if (this.size <= 0) {
       this.begin()
       return
-    } else if (action === this.head) {
+    }
+
+    // reset head/root references if necessary
+    if (action === this.head) {
       next = this.head = parent
     } else if (action === this.root) {
       this.root = next
     }
 
-    if (!action.disabled) {
-      this.reconcile(this.head)
+    // reconcile history if action was in active history branch
+    if (wasActive && !action.disabled) {
+      this.reconcile(next)
     }
   }
 
@@ -296,6 +303,14 @@ class History extends Emitter {
     }
 
     this.size = size
+  }
+
+  /**
+   * Determine if provided action is within active history branch
+   * @param {Action} action
+   */
+  isActive(action) {
+    return this.toArray().indexOf(action) >= 0
   }
 }
 

--- a/src/history.js
+++ b/src/history.js
@@ -193,8 +193,8 @@ class History extends Emitter {
       this.root = next
     }
 
-    if (!action.disabled && next) {
-      this.reconcile(next)
+    if (!action.disabled) {
+      this.reconcile(this.head)
     }
   }
 

--- a/src/history.js
+++ b/src/history.js
@@ -187,7 +187,7 @@ class History extends Emitter {
     if (this.size <= 0) {
       this.begin()
       return
-    } else if (action === this.head && !next) {
+    } else if (action === this.head) {
       next = this.head = parent
     } else if (action === this.root) {
       this.root = next

--- a/src/history.js
+++ b/src/history.js
@@ -187,13 +187,13 @@ class History extends Emitter {
     if (this.size <= 0) {
       this.begin()
       return
-    } else if (!next) {
+    } else if (action === this.head && !next) {
       next = this.head = parent
     } else if (action === this.root) {
       this.root = next
     }
 
-    if (!action.disabled) {
+    if (!action.disabled && next) {
       this.reconcile(next)
     }
   }

--- a/test/unit/history/isActive.test.js
+++ b/test/unit/history/isActive.test.js
@@ -1,0 +1,36 @@
+import History from '../../../src/history'
+
+describe('History::isActive', function() {
+  const action = n => n
+  const history = new History()
+
+  /*
+   * Set up the following tree:
+   *
+   *               |- [three] - [four]
+   * [one] - [two] +
+   *               |- [five] - [*six]
+   */
+
+  const one = history.append(action)
+  const two = history.append(action)
+  const three = history.append(action)
+  const four = history.append(action)
+
+  history.checkout(two)
+
+  const five = history.append(action)
+  const six = history.append(action)
+
+  it('returns true for actions in the active branch', function() {
+    expect(history.isActive(one)).toEqual(true)
+    expect(history.isActive(two)).toEqual(true)
+    expect(history.isActive(five)).toEqual(true)
+    expect(history.isActive(six)).toEqual(true)
+  })
+
+  it('returns false for actions not in the active branch', function() {
+    expect(history.isActive(three)).toEqual(false)
+    expect(history.isActive(four)).toEqual(false)
+  })
+})

--- a/test/unit/history/remove.test.js
+++ b/test/unit/history/remove.test.js
@@ -141,6 +141,27 @@ describe('History::remove', function() {
     })
   })
 
+  describe('removing an unfocused branch terminator', function() {
+    it('leaves the head reference alone', function() {
+      let history = new History({ maxHistory: Infinity })
+
+      let one = history.append(function one() {}, 'resolve')
+      let two = history.append(function two() {}, 'resolve')
+
+      history.checkout(one)
+      let three = history.append(function three() {}, 'resolve')
+
+      // History tree now looks like this:
+      //                |- [two]
+      // [root] - [one] +
+      //                |- [*three]
+
+      history.remove(two)
+
+      expect(history.head.id).toBe(three.id)
+    })
+  })
+
   describe('children', function() {
     it('eliminates references to removed on the left', function() {
       let history = new History({ maxHistory: Infinity })

--- a/test/unit/history/remove.test.js
+++ b/test/unit/history/remove.test.js
@@ -68,8 +68,6 @@ describe('History::remove', function() {
       history.append(function two() {}, 'resolve')
       let three = history.append(function three() {}, 'resolve')
 
-      history.archive()
-
       history.remove(three)
 
       expect(history.map(a => a.command.name)).toEqual(['$start', 'one', 'two'])
@@ -81,8 +79,6 @@ describe('History::remove', function() {
       history.append(function one() {}, 'resolve')
       history.append(function two() {}, 'resolve')
       let three = history.append(function three() {}, 'resolve')
-
-      history.archive()
 
       history.remove(three)
 
@@ -113,8 +109,6 @@ describe('History::remove', function() {
       history.append(function two() {}, 'resolve')
       history.append(function three() {}, 'resolve')
 
-      history.archive()
-
       history.remove(history.root)
 
       expect(history.map(a => a.command.name)).toEqual(['one', 'two', 'three'])
@@ -128,8 +122,6 @@ describe('History::remove', function() {
       history.append(function one() {}, 'resolve')
       let two = history.append(function two() {}, 'resolve')
       history.append(function three() {}, 'resolve')
-
-      history.archive()
 
       history.remove(two)
 

--- a/test/unit/history/remove.test.js
+++ b/test/unit/history/remove.test.js
@@ -144,6 +144,52 @@ describe('History::remove', function() {
 
       expect(history.head.id).toBe(one.id)
     })
+
+    it('reconciles at the next action', function() {
+      let history = new History({ maxHistory: Infinity })
+
+      history.append(function one() {}, 'resolve')
+      let two = history.append(function two() {}, 'resolve')
+      let three = history.append(function three() {}, 'resolve')
+
+      jest.spyOn(history, 'reconcile')
+
+      history.remove(two)
+
+      expect(history.reconcile).toHaveBeenCalledWith(three)
+    })
+
+    it('reconciles at the parent if the action is head of an active branch', function() {
+      let history = new History({ maxHistory: Infinity })
+
+      let one = history.append(function one() {}, 'resolve')
+      let two = history.append(function two() {}, 'resolve')
+      history.append(function three() {}, 'resolve')
+
+      history.checkout(two)
+
+      jest.spyOn(history, 'reconcile')
+
+      history.remove(two)
+
+      expect(history.reconcile).toHaveBeenCalledWith(one)
+    })
+
+    it('does not reconcile if the action is not in active branch', function() {
+      let history = new History({ maxHistory: Infinity })
+
+      history.append(function one() {}, 'resolve')
+      let two = history.append(function two() {}, 'resolve')
+      let three = history.append(function three() {}, 'resolve')
+
+      history.checkout(two)
+
+      jest.spyOn(history, 'reconcile')
+
+      history.remove(three)
+
+      expect(history.reconcile).not.toHaveBeenCalled()
+    })
   })
 
   describe('removing an unfocused branch terminator', function() {

--- a/test/unit/history/remove.test.js
+++ b/test/unit/history/remove.test.js
@@ -139,6 +139,19 @@ describe('History::remove', function() {
         'three'
       ])
     })
+
+    it('resets the head if removing the head', function() {
+      let history = new History({ maxHistory: Infinity })
+
+      let one = history.append(function one() {}, 'resolve')
+      let two = history.append(function two() {}, 'resolve')
+      history.append(function three() {}, 'resolve')
+
+      history.checkout(two)
+      history.remove(two)
+
+      expect(history.head.id).toBe(one.id)
+    })
   })
 
   describe('removing an unfocused branch terminator', function() {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing applications:

**Does this PR fulfill these requirements:**

- [x] All tests are passing

**Additional Information**

This PR fixes two bugs:
- If you remove an action which has no `next` reference, History assumed you were removing the head action and automatically set the head to the action's parent. This ensures that the head is reset only if the action being removed was the existing head.
- If you remove the head action, set the head to the removed action's parent