### PR TITLE
Move more query/node concerns to their associated modules

### DIFF
--- a/src/compare-tree/index.js
+++ b/src/compare-tree/index.js
@@ -1,6 +1,6 @@
 import Node from './node'
 import Query from './query'
-import { getKeyPaths, getKeyString } from '../key-path'
+import { getKeyString } from '../key-path'
 
 // The root key is an empty string. This can be a little
 // counter-intuitive, so we keep track of them as a named constant.
@@ -23,16 +23,11 @@ class CompareTree {
    * @param {*} [scope] Optional scope to invoke the function with
    */
   on(keyPaths, callback, scope) {
-    let dependencies = getKeyPaths(keyPaths)
-    let id = Query.getId(keyPaths)
-
-    let query = this.addQuery(id, dependencies)
-
-    for (var i = 0; i < dependencies.length; i++) {
-      this.addBranch(dependencies[i], query)
-    }
+    let query = this.addQuery(keyPaths)
 
     query.on('change', callback, scope)
+
+    query.forEachPath(this.addBranch, this)
 
     return query
   }
@@ -104,9 +99,11 @@ class CompareTree {
    * @param {String} id Identifier for the node.
    * @param {String} keyPaths Each query tracks a list of key paths
    */
-  addQuery(id, keyPaths) {
+  addQuery(dependencies) {
+    let id = Query.getId(dependencies)
+
     if (!this.nodes[id]) {
-      this.nodes[id] = new Query(id, keyPaths)
+      this.nodes[id] = new Query(id, dependencies)
     }
 
     return this.nodes[id]

--- a/src/compare-tree/query.js
+++ b/src/compare-tree/query.js
@@ -18,6 +18,14 @@ class Query extends Emitter {
     this.keyPaths = getKeyPaths(keys)
   }
 
+  forEachPath(callback, scope) {
+    let paths = this.keyPaths
+
+    for (var i = 0, len = paths.length; i < len; i++) {
+      callback.call(scope, paths[i], this)
+    }
+  }
+
   extract(state) {
     let length = this.keyPaths.length
     let values = Array(length)

--- a/src/key-path.js
+++ b/src/key-path.js
@@ -42,6 +42,8 @@ export function getKeyPaths(value) {
 
   if (Array.isArray(value) === false) {
     paths = `${paths}`.split(PATH_DELIMETER)
+  } else if (value.every(Array.isArray)) {
+    return value
   }
 
   return paths.map(castPath)

--- a/test/unit/compare-tree/query.test.js
+++ b/test/unit/compare-tree/query.test.js
@@ -1,0 +1,16 @@
+import Query from '../../../src/compare-tree/query'
+
+describe('CompareTree > Query', function() {
+  describe('#forEachPath', function() {
+    it('enumerates through the given dependencies', function() {
+      let query = new Query('1', 'foo.bar,bip.baz')
+      let answer = {}
+
+      query.forEachPath(path => {
+        answer[path.join('.')] = true
+      })
+
+      expect(answer).toEqual({ 'foo.bar': true, 'bip.baz': true })
+    })
+  })
+})

--- a/test/unit/key-path/get-key-paths.test.js
+++ b/test/unit/key-path/get-key-paths.test.js
@@ -45,4 +45,11 @@ describe('getKeyPaths', function() {
     expect(path[0]).toEqual(['foo'])
     expect(path[1]).toEqual(['b ar'])
   })
+
+  it('returns the same array if every value is an array', function() {
+    let path = [['foo', 'bar'], ['bip', 'baz']]
+    let answer = getKeyPaths(path)
+
+    expect(answer).toBe(path)
+  })
 })


### PR DESCRIPTION
Microcosm has an internal tree for comparing data. This is so that you can do things like `repo.on('change:planets', (planets) => {})`. This commit reduces some responsbilities inside of the comparison tree itself so that individual nodes have greater encapsulation.

I've also added an efficiency for calculating keypaths that avoids re-parsing array-form keypaths. Paths that are already in the correct form are not additionally parsed. 

For example:

```javascript
let path = [['foo', 'bar']]
let parsed = castPath(path)

assert.equal(path, parsed)
```