### PR TITLE
Add flow types for domain and effect engines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,8 +20,13 @@
       "jsx": true
     }
   },
-  "extends": ["eslint:recommended"],
-  "plugins": [ "import", "react" ],
+  "settings": {
+    "flowtype": {
+      "onlyFilesWithFlowAnnotation": true
+    }
+  },
+  "extends": ["eslint:recommended", "plugin:flowtype/recommended"],
+  "plugins": [ "import", "react", "flowtype" ],
   "rules": {
     "semi": [2, "never"],
     "sort-vars": 2,

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,9 +1,11 @@
 [ignore]
-test
+test/
+.*/node_modules/.*
 
 [include]
-src
+src/
 
 [libs]
+flow/
 
 [options]

--- a/flow/registry.js
+++ b/flow/registry.js
@@ -1,0 +1,19 @@
+/**
+ * @flow
+ * eslint-disable
+ */
+
+import type Microcosm from '../src/microcosm'
+import type Registration from '../src/registration'
+
+declare type Handler = (last?: *, next?: *) => mixed
+
+declare type Registrations = Array<Registration>
+
+declare interface Registerable {
+  register(): Registrations,
+
+  setup(repo: Microcosm, options: ?Object): void,
+
+  teardown(repo: Microcosm): void
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "elizabot": "^0.0.2",
     "enzyme": "^2.8.2",
     "eslint": "^4.0.0",
+    "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^7.0.1",
     "flow-bin": "^0.48.0",

--- a/src/effect-engine.js
+++ b/src/effect-engine.js
@@ -2,7 +2,6 @@
  * @flow
  */
 
-import Registration from './registration'
 import getRegistration from './get-registration'
 import { createOrClone } from './utils'
 

--- a/src/effect-engine.js
+++ b/src/effect-engine.js
@@ -1,17 +1,25 @@
+/**
+ * @flow
+ */
+
+import Registration from './registration'
 import getRegistration from './get-registration'
 import { createOrClone } from './utils'
 
+import type Action from './action'
+import type Microcosm from './microcosm'
+
 class EffectEngine {
-  /**
-   * @param {Microcosm} repo
-   */
-  constructor(repo) {
+  repo: Microcosm
+  effects: Array<Registerable>
+
+  constructor(repo: Microcosm) {
     this.repo = repo
     this.effects = []
   }
 
-  add(config, options) {
-    let effect = createOrClone(config, options, this.repo)
+  add(config: Object | Function, options?: Object) {
+    let effect: Registerable = createOrClone(config, options, this.repo)
 
     if (effect.setup) {
       effect.setup(this.repo, options)
@@ -26,7 +34,7 @@ class EffectEngine {
     return effect
   }
 
-  dispatch(action) {
+  dispatch(action: Action) {
     let { command, payload, status } = action
 
     for (var i = 0, len = this.effects.length; i < len; i++) {

--- a/src/key-path.js
+++ b/src/key-path.js
@@ -1,4 +1,5 @@
 /**
+ * @flow
  * A key path is a list of property names that describe a pathway
  * through a nested javascript object. For example, `['users', 2]`
  * could represent a path within in `{ users: [{id: 0}, {id: 1}] }`
@@ -6,10 +7,12 @@
 
 import { isString } from './utils'
 
+export type KeyPath = Array<string>
+
 const KEY_DELIMETER = '.'
 const PATH_DELIMETER = ','
 
-function isBlank(value) {
+function isBlank(value: *): boolean {
   return value === '' || value === null || value === undefined
 }
 
@@ -19,7 +22,7 @@ function isBlank(value) {
  * @return {Array} List of keys, like ['users', 2]
  * @private
  */
-export function castPath(value) {
+export function castPath(value: string | KeyPath): KeyPath {
   if (Array.isArray(value)) {
     return value
   } else if (isBlank(value)) {
@@ -37,7 +40,7 @@ export function castPath(value) {
  * @return {Array} List of paths, like [['users'], ['query', 'focus']]
  * @private
  */
-export function getKeyPaths(value) {
+export function getKeyPaths(value: *): Array<KeyPath> {
   let paths = value
 
   if (Array.isArray(value) === false) {
@@ -55,7 +58,7 @@ export function getKeyPaths(value) {
  * @return {String} Dot separated string, like 'query.focus'
  * @private
  */
-export function getKeyString(value) {
+export function getKeyString(value: KeyPath): string {
   return value.join(KEY_DELIMETER)
 }
 
@@ -65,6 +68,6 @@ export function getKeyString(value) {
  * @return {Array} Comma key paths, like 'users,query.focus'
  * @private
  */
-export function getKeyStrings(array) {
+export function getKeyStrings(array: Array<KeyPath>): string {
   return array.map(getKeyString).join(PATH_DELIMETER)
 }

--- a/src/registration.js
+++ b/src/registration.js
@@ -1,0 +1,19 @@
+/**
+ * @flow
+ */
+
+import { type KeyPath } from './key-path'
+
+class Registration {
+  key: KeyPath
+  domain: Registerable
+  handler: Handler
+
+  constructor(key: KeyPath, domain: Registerable, handler: Handler) {
+    this.key = key
+    this.domain = domain
+    this.handler = handler
+  }
+}
+
+export default Registration

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,6 +1970,12 @@ eslint-module-utils@^2.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
+eslint-plugin-flowtype@^2.34.0:
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.34.0.tgz#b9875f314652e5081623c9d2b18a346bbb759c09"
+  dependencies:
+    lodash "^4.15.0"
+
 eslint-plugin-import@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz#37c801e0ada0e296cbdf20c3f393acb5b52af36b"
@@ -3614,7 +3620,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Adds flow types for the domain and effect engines. Still lots of Flow learning to do. 

One thing I'm curious about are data types. For example, checkout `Registration`. I'm using a class for this, but is that appropriate? Generally I don't like to use classes for "data bags", but having the type automatically generated is nice.

Also I'm finding places where my code is simply too general (see `utils.js :: createOrClone`). I could see some eventual refactoring here to make things more explicit.