### PR TITLE
Add flow types to utilities. Optimize merge.

### DIFF
--- a/flow/registry.js
+++ b/flow/registry.js
@@ -6,7 +6,7 @@
 import type Microcosm from '../src/microcosm'
 import type Registration from '../src/registration'
 
-declare type Handler = (last?: *, next?: *) => mixed
+declare type Handler = <T>(last?: T, next?: *) => T
 
 declare type Registrations = Array<Registration>
 

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -129,7 +129,7 @@ class DomainEngine {
     return next
   }
 
-  dispatch(state: Object, action: Action) {
+  dispatch(state: Object, action: Action): Object {
     let handlers = this.register(action)
 
     for (var i = 0, len = handlers.length; i < len; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,33 +39,27 @@ export function clone(target: ?Object): Object {
  * @private
  */
 export function merge(): Object {
-  var copy = {}
-  var first = copy
-  var dirty = false
+  let copy = null
+  let subject = null
 
-  for (var i = arguments.length - 1; i >= 0; i--) {
-    var subject = arguments[i]
+  for (var i = 0, len = arguments.length; i < len; i++) {
+    copy = copy || arguments[i]
+    subject = subject || copy
 
-    if (isObject(subject) === false) {
-      continue
-    }
+    var next = arguments[i]
 
-    if (first === copy) {
-      first = subject
-    }
+    for (var key in next) {
+      if (copy[key] !== next[key]) {
+        if (copy === subject) {
+          copy = clone(subject)
+        }
 
-    for (var key in subject) {
-      if (!dirty) {
-        dirty = key in first === false
-      }
-
-      if (key in copy === false) {
-        copy[key] = subject[key]
+        copy[key] = next[key]
       }
     }
   }
 
-  return dirty ? copy : first
+  return copy || {}
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -161,7 +161,7 @@ export function isObject(target: *): boolean {
  * @return {boolean}
  * @private
  */
-export function isFunction(target: *): boolean {
+export function isFunction(target: any): boolean {
   return !!target && typeof target === 'function'
 }
 
@@ -171,7 +171,7 @@ export function isFunction(target: *): boolean {
  * @return {boolean}
  * @private
  */
-export function isString(target: *): boolean {
+export function isString(target: any): boolean {
   return typeof target === 'string'
 }
 
@@ -183,7 +183,7 @@ export function isString(target: *): boolean {
  */
 const $Symbol = typeof Symbol === 'function' ? Symbol : {}
 const toStringTagSymbol = $Symbol.toStringTag || '@@toStringTag'
-export function toStringTag(value: *): string {
+export function toStringTag(value: any): string {
   if (!value) {
     return ''
   }
@@ -198,14 +198,14 @@ export function toStringTag(value: *): string {
  * @return {boolean}
  * @private
  */
-export function isGeneratorFn(value: *): boolean {
+export function isGeneratorFn(value: any): boolean {
   return toStringTag(value) === 'GeneratorFunction'
 }
 
 /**
  * @private
  */
-export function createOrClone(target: *, options: ?Object, repo: Microcosm) {
+export function createOrClone(target: any, options: ?Object, repo: Microcosm) {
   if (isFunction(target)) {
     return new target(options, repo)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ export function merge(): Object {
  * object.
  * @private
  */
-export function get(object: ?Object, keyPath: string | KeyPath, fallback: ?*) {
+export function get(object: ?Object, keyPath: string | KeyPath, fallback?: *) {
   if (object == null) {
     return fallback
   }
@@ -231,7 +231,7 @@ export function update(
   state: *,
   keyPath: string | KeyPath,
   updater: *,
-  fallback: *
+  fallback?: *
 ) {
   let path = castPath(keyPath)
 

--- a/test/unit/utils/clone.test.js
+++ b/test/unit/utils/clone.test.js
@@ -26,23 +26,25 @@ describe('Utils.clone', function() {
     expect(copy).not.toBe(original)
   })
 
-  it('does not clone strings', function() {
-    expect(clone('a')).toBe('a')
-  })
+  describe('non-object values', function() {
+    it('does not clone strings', function() {
+      expect(clone('a')).toEqual({})
+    })
 
-  it('does not clone numbers', function() {
-    expect(clone(1)).toBe(1)
-  })
+    it('does not clone numbers', function() {
+      expect(clone(1)).toEqual({})
+    })
 
-  it('does not clone booleans', function() {
-    expect(clone(true)).toBe(true)
-  })
+    it('does not clone booleans', function() {
+      expect(clone(true)).toEqual({})
+    })
 
-  it('does not clone null', function() {
-    expect(clone(null)).toBe(null)
-  })
+    it('does not clone null', function() {
+      expect(clone(null)).toEqual({})
+    })
 
-  it('does not clone undefined', function() {
-    expect(clone(undefined)).toBe(undefined)
+    it('does not clone undefined', function() {
+      expect(clone(undefined)).toEqual({})
+    })
   })
 })

--- a/test/unit/utils/merge.test.js
+++ b/test/unit/utils/merge.test.js
@@ -27,7 +27,7 @@ describe('Utils.merge', function() {
     const b = { foo: 'bar' }
     const c = { foo: 'bar' }
 
-    expect(merge(a, b, c)).toBe(b)
+    expect(merge(a, b, c)).toBe(c)
   })
 
   it('merges many arguments', function() {
@@ -42,7 +42,7 @@ describe('Utils.merge', function() {
     const a = { foo: 'bar' }
     const b = { foo: 'bar' }
 
-    expect(merge(null, a, null, b)).toBe(a)
+    expect(merge(null, a, null, b)).toBe(b)
   })
 
   it('copys even with falsy middle arguments', function() {
@@ -51,8 +51,7 @@ describe('Utils.merge', function() {
     const c = merge(null, a, null, b)
 
     expect(c).not.toBe(a)
-    expect(c).not.toBe(b)
-    expect(c).toEqual(b)
+    expect(c).toBe(b)
   })
 
   it('handles subsequent null arguments', function() {
@@ -61,17 +60,63 @@ describe('Utils.merge', function() {
     const c = merge(null, null, a, b)
 
     expect(c).not.toBe(a)
-    expect(c).not.toBe(b)
-    expect(c).toEqual(b)
+    expect(c).toBe(b)
   })
 
   it('handles mixtures of undefined and null', function() {
+    const a = { green: true }
+    const b = { blue: true }
+    const c = merge(a, null, b, undefined)
+
+    expect(c).not.toBe(a)
+    expect(c).not.toBe(b)
+    expect(c).toEqual({ green: true, blue: true })
+  })
+
+  it('when there are no unique keys, it returns the last object', function() {
     const a = { foo: 'bar' }
     const b = { foo: 'baz' }
     const c = merge(a, null, b, undefined)
 
     expect(c).not.toBe(a)
+    expect(c).toBe(b)
+  })
+
+  it('returns the last object when the left most value is a superset', function() {
+    const a = { red: true }
+    const b = { red: true, green: true }
+    const c = merge(a, null, b, undefined)
+
+    expect(c).not.toBe(a)
+    expect(c).toBe(b)
+  })
+
+  it('uses the left value when it is a superset of the right', function() {
+    const a = { red: false }
+    const b = { red: true, green: true }
+    const c = merge(a, null, b, undefined)
+
+    expect(c).not.toBe(a)
+    expect(c).toBe(b)
+  })
+
+  it('returns a new object when the last object is not a superset', function() {
+    const a = { red: false, blue: true }
+    const b = { red: true, green: true }
+    const c = merge(a, null, b, undefined)
+
+    expect(c).not.toBe(a)
     expect(c).not.toBe(b)
-    expect(c).toEqual(b)
+    expect(c).toEqual({ red: true, green: true, blue: true })
+  })
+
+  // TODO: We can recycle supersets from the right to the left. How can we
+  // recycle from the left to the right?
+  xit('uses the right value when it is a superset of the left', function() {
+    const a = { red: true, green: true, blue: true }
+    const b = { red: true, green: true }
+    const c = merge(a, null, b, undefined)
+
+    expect(c).toBe(a)
   })
 })

--- a/test/unit/utils/merge.test.js
+++ b/test/unit/utils/merge.test.js
@@ -27,7 +27,17 @@ describe('Utils.merge', function() {
     const b = { foo: 'bar' }
     const c = { foo: 'bar' }
 
-    expect(merge(a, b, c)).toBe(c)
+    expect(merge(a, b, c)).toBe(b)
+  })
+
+  it('returns a new copy when the left most value is an empty object', function() {
+    const a = {}
+    const b = { foo: 'bar' }
+
+    const answer = merge(a, b)
+
+    expect(answer).not.toBe(b)
+    expect(answer).toEqual(b)
   })
 
   it('merges many arguments', function() {
@@ -42,16 +52,15 @@ describe('Utils.merge', function() {
     const a = { foo: 'bar' }
     const b = { foo: 'bar' }
 
-    expect(merge(null, a, null, b)).toBe(b)
+    expect(merge(null, a, null, b)).toBe(a)
   })
 
-  it('copys even with falsy middle arguments', function() {
+  it('copies even with falsy middle arguments', function() {
     const a = { foo: 'bar' }
     const b = { foo: 'baz' }
     const c = merge(null, a, null, b)
 
-    expect(c).not.toBe(a)
-    expect(c).toBe(b)
+    expect(c).toEqual(b)
   })
 
   it('handles subsequent null arguments', function() {
@@ -59,8 +68,8 @@ describe('Utils.merge', function() {
     const b = { foo: 'baz' }
     const c = merge(null, null, a, b)
 
-    expect(c).not.toBe(a)
-    expect(c).toBe(b)
+    expect(c).not.toBe(b)
+    expect(c).toEqual(b)
   })
 
   it('handles mixtures of undefined and null', function() {
@@ -79,7 +88,7 @@ describe('Utils.merge', function() {
     const c = merge(a, null, b, undefined)
 
     expect(c).not.toBe(a)
-    expect(c).toBe(b)
+    expect(c).toEqual(b)
   })
 
   it('returns the last object when the left most value is a superset', function() {
@@ -88,16 +97,7 @@ describe('Utils.merge', function() {
     const c = merge(a, null, b, undefined)
 
     expect(c).not.toBe(a)
-    expect(c).toBe(b)
-  })
-
-  it('uses the left value when it is a superset of the right', function() {
-    const a = { red: false }
-    const b = { red: true, green: true }
-    const c = merge(a, null, b, undefined)
-
-    expect(c).not.toBe(a)
-    expect(c).toBe(b)
+    expect(c).toEqual(b)
   })
 
   it('returns a new object when the last object is not a superset', function() {
@@ -105,18 +105,51 @@ describe('Utils.merge', function() {
     const b = { red: true, green: true }
     const c = merge(a, null, b, undefined)
 
-    expect(c).not.toBe(a)
-    expect(c).not.toBe(b)
     expect(c).toEqual({ red: true, green: true, blue: true })
   })
 
-  // TODO: We can recycle supersets from the right to the left. How can we
-  // recycle from the left to the right?
-  xit('uses the right value when it is a superset of the left', function() {
+  it('uses the right value when it is a superset of the left', function() {
     const a = { red: true, green: true, blue: true }
     const b = { red: true, green: true }
-    const c = merge(a, null, b, undefined)
+    const c = merge(a, b)
 
     expect(c).toBe(a)
+  })
+
+  it('an empty object does not cause keys to drop', function() {
+    const a = { color: 'red' }
+    const b = {}
+
+    expect(merge(a, b)).toBe(a)
+  })
+
+  it('undefined in the middle of different keys does not cause keys to drop', function() {
+    const a = { parent: null, maxHistory: 0, batch: false }
+    const b = undefined
+    const c = { parent: true }
+
+    expect(merge(a, b, c)).toEqual({
+      parent: true,
+      maxHistory: 0,
+      batch: false
+    })
+  })
+
+  describe('arrays', function() {
+    it('merges a larger array into a smaller array', function() {
+      let answer = merge([1, 2], [1, 2, 3])
+
+      expect(Array.isArray(answer)).toBe(true)
+
+      expect(answer).toEqual([1, 2, 3])
+    })
+
+    it('merges a smaller array into a larger array', function() {
+      let answer = merge([1, 2, 3], [1, 2])
+
+      expect(Array.isArray(answer)).toBe(true)
+
+      expect(answer).toEqual([1, 2, 3])
+    })
   })
 })


### PR DESCRIPTION
This commit adds flow types to the utilities module. It also uncovers an optimization where we can avoid returning a new object when the right-most value of a `merge` call is a superset. For example:

```javascript
let left = { green: true }
let right = { green: true, blue: true }
let answer = merge(left, right)

expect(answer).toBe(right)
```

We can just return the right-most value because it contains no differences with the left.