### PR TITLE
Rework sanitize process, simplify domain engine

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -2,6 +2,8 @@
  * @flow
  */
 
+import { mergeSame } from './utils'
+
 import type Action from './action'
 import type Microcosm from './microcosm'
 
@@ -17,12 +19,9 @@ function sandbox(data: Object, deserialize: boolean) {
         throw error
       }
     }
-
     // Strip out keys not managed by this repo. This prevents children from
     // accidentally having their keys reset by parents.
-    let sanitary = repo.domains.sanitize(payload)
-
-    action.resolve(sanitary)
+    action.resolve(mergeSame(repo.state, payload))
   }
 }
 

--- a/src/meta-domain.js
+++ b/src/meta-domain.js
@@ -4,7 +4,7 @@
  * @flow
  */
 
-import { merge } from './utils'
+import { mergeSame, merge } from './utils'
 import { RESET, PATCH, ADD_DOMAIN } from './lifecycle'
 
 class MetaDomain {
@@ -18,7 +18,7 @@ class MetaDomain {
    * Build a new Microcosm state object.
    */
   reset(oldState: Object, newState: Object): Object {
-    let filtered = this.repo.domains.sanitize(newState)
+    let filtered = mergeSame(oldState, newState)
 
     return merge(oldState, this.repo.getInitialState(), filtered)
   }
@@ -27,7 +27,7 @@ class MetaDomain {
    * Merge a state object into the current Microcosm state.
    */
   patch(oldState: Object, newState: Object): Object {
-    let filtered = this.repo.domains.sanitize(newState)
+    let filtered = mergeSame(oldState, newState)
 
     return merge(oldState, filtered)
   }

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -323,10 +323,9 @@ class Microcosm extends Emitter implements Domain {
    */
   addDomain(key: string, config: *, options?: Object) {
     let domain = this.domains.add(key, config, options)
+    let initial = domain.getInitialState ? domain.getInitialState() : null
 
-    if (domain.getInitialState) {
-      this.initial = set(this.initial, key, domain.getInitialState())
-    }
+    this.initial = set(this.initial, key, initial)
 
     this.push(ADD_DOMAIN, domain)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,8 @@
 import type Microcosm from './microcosm'
 import { castPath, type KeyPath } from './key-path'
 
+type MixedObject = { [key: string]: mixed }
+
 /**
  * Generate a unique id
  */
@@ -14,9 +16,25 @@ export function uid(prefix: string): string {
 }
 
 /**
+ * Merge on object into the next, but only assign keys that are
+ * defined in the base.
+ */
+export function mergeSame<T: MixedObject>(target: T, head: Object): $Shape<T> {
+  let next = {}
+
+  for (var key in head) {
+    if (key in target) {
+      next[key] = head[key]
+    }
+  }
+
+  return next
+}
+
+/**
  * Shallow copy an object
  */
-export function clone<T: { [key: string]: mixed }>(target: T): $Shape<T> {
+export function clone<T: MixedObject>(target: T): $Shape<T> {
   if (Array.isArray(target)) {
     return target.slice(0)
   } else if (isObject(target) === false) {
@@ -82,7 +100,7 @@ export function get(object: ?Object, keyPath: *, fallback?: *) {
  * Non-destructively assign a value to a provided object at a given key. If the
  * value is the same, don't do anything. Otherwise return a new object.
  */
-export function set(object: Object, key: string | KeyPath, value: *): Object {
+export function set(object: Object, key: *, value: *): any {
   // Ensure we're working with a key path, like: ['a', 'b', 'c']
   let path = castPath(key)
 


### PR DESCRIPTION
This commit reworks the sanitization process to avoid some extra inefficiency. Additionally it cuts some code from the domain engine.

This was bugging me for a while since @efatsi pointed it out. Hopefully this makes things a bit nicer.