### PR TITLE
History is an iterator

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -127,10 +127,10 @@ class Action extends Emitter {
     let outstanding = actions.length
 
     const onResolve = () => {
-      outstanding -= 1
-
-      if (outstanding <= 0) {
+      if (outstanding <= 1) {
         this.resolve()
+      } else {
+        outstanding -= 1
       }
     }
 
@@ -139,6 +139,8 @@ class Action extends Emitter {
       action.onCancel(onResolve)
       action.onError(this.reject)
     })
+
+    onResolve()
 
     return this
   }
@@ -268,6 +270,10 @@ class Action extends Emitter {
     this._emit(status, this.payload)
 
     return this
+  }
+
+  toString() {
+    return this.command.toString()
   }
 
   toJSON() {

--- a/src/archive.js
+++ b/src/archive.js
@@ -25,7 +25,7 @@ class Archive {
    * Access a prior snapshot for a given action
    */
   get(action: ?Action, fallback: ?Object): Object {
-    console.assert(action, 'Unable to get ' + typeof action + ' action')
+    console.assert(action, 'Unable to get %s action', action)
 
     if (action && this.has(action)) {
       return this.pool[action.id]
@@ -52,7 +52,7 @@ class Archive {
    * Remove a snapshot for an action.
    */
   remove(action: Action) {
-    console.assert(action, 'Unable to remove ' + typeof action + ' action.')
+    console.assert(action, 'Unable to remove %s action.', action)
 
     delete this.pool[action.id]
   }

--- a/src/history.js
+++ b/src/history.js
@@ -10,7 +10,7 @@ import Action from './action'
 import Emitter from './emitter'
 import defaultUpdateStrategy from './default-update-strategy'
 import { merge } from './utils'
-import { BIRTH, START } from './lifecycle'
+import { BIRTH, START, ADD_DOMAIN } from './lifecycle'
 import { type Updater } from './default-update-strategy'
 import { iteratorTag } from './symbols'
 
@@ -118,9 +118,9 @@ class History extends Emitter {
    */
   // $FlowFixMe
   [iteratorTag](): Iterator<Action, void> {
-    var cursor = this.root
+    let cursor = this.root
 
-    return {
+    let iterator = {
       next: () => {
         var next = cursor
 
@@ -130,9 +130,17 @@ class History extends Emitter {
 
         cursor = next == this.head ? null : cursor.next
 
+        // Ignore certain lifecycle actions that are only for
+        // internal purposes
+        if (next && (next.command === BIRTH || next.command === START || next.command === ADD_DOMAIN)) {
+          return iterator.next()
+        }
+
         return { value: next, done: false }
       }
     }
+
+    return iterator
   }
 
   map(fn: (action: Action, index: number) => *, scope?: Object) {
@@ -385,6 +393,10 @@ class History extends Emitter {
     }
 
     return this.head
+  }
+
+  toString() {
+    return this.toArray().join(', ')
   }
 
   /**

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,0 +1,10 @@
+/**
+ * @flow
+ */
+import { get, isFunction } from './utils'
+
+const $Symbol = isFunction(Symbol) ? Symbol : {}
+
+export const toStringTag: * = get($Symbol, 'toStringTag', '@@toStringTag')
+
+export const iteratorTag: * = get($Symbol, 'iterator', '@@iterator')

--- a/src/utils.js
+++ b/src/utils.js
@@ -222,6 +222,6 @@ export function update(
 /**
  * A couple of methods use identity functions. This avoids duplication.
  */
-export function identity<T>(n: T): T {
+export function identity(n: *) {
   return n
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@
 
 import type Microcosm from './microcosm'
 import { castPath, type KeyPath } from './key-path'
+import { toStringTag } from './symbols'
 
 type MixedObject = { [key: string]: mixed }
 
@@ -173,14 +174,12 @@ export function isBlank(value: any): boolean {
  * some legacy support.
  */
 /* istanbul ignore next */
-const $Symbol = typeof Symbol === 'function' ? Symbol : {}
-const toStringTagSymbol = get($Symbol, 'toStringTag', '@@toStringTag')
-export function toStringTag(value: any): string {
+export function getStringTag(value: any): string {
   if (!value) {
     return ''
   }
 
-  return value[toStringTagSymbol] || ''
+  return value[toStringTag] || ''
 }
 
 /**
@@ -188,7 +187,7 @@ export function toStringTag(value: any): string {
  * informed by the regenerator runtime.
  */
 export function isGeneratorFn(value: any): boolean {
-  return toStringTag(value) === 'GeneratorFunction'
+  return getStringTag(value) === 'GeneratorFunction'
 }
 
 export function createOrClone(target: any, options: ?Object, repo: Microcosm) {
@@ -218,4 +217,11 @@ export function update(
   let next = updater(last)
 
   return set(state, path, next)
+}
+
+/**
+ * A couple of methods use identity functions. This avoids duplication.
+ */
+export function identity<T>(n: T): T {
+  return n
 }

--- a/test/unit/history/archive.test.js
+++ b/test/unit/history/archive.test.js
@@ -68,9 +68,9 @@ describe('History::archive', function() {
   it('archived nodes have no relations', function() {
     const history = new History()
 
-    history.append(action).resolve()
+    history.append('one').resolve()
 
-    history.append(action)
+    history.append('two')
 
     history.archive()
 

--- a/test/unit/history/iterator.test.js
+++ b/test/unit/history/iterator.test.js
@@ -10,7 +10,7 @@ describe('History @@iterator', function() {
 
     let list = Array.from(history)
 
-    expect(list.map(i => i.type)).toEqual(['$start.1', 'one', 'two'])
+    expect(list.map(i => i.type)).toEqual(['one', 'two'])
   })
 
   it('works with for...of', function() {
@@ -25,7 +25,7 @@ describe('History @@iterator', function() {
       list.push(action.type)
     }
 
-    expect(list).toEqual(['$start.1', 'one', 'two'])
+    expect(list).toEqual(['one', 'two'])
   })
 
   it('works with Promise.all', async function() {

--- a/test/unit/history/iterator.test.js
+++ b/test/unit/history/iterator.test.js
@@ -1,0 +1,64 @@
+import History from '../../../src/history'
+import Observable from 'zen-observable'
+
+describe('History @@iterator', function() {
+  it('works with Array.from', function() {
+    let history = new History({ maxHistory: Infinity })
+
+    history.append('one', 'resolve')
+    history.append('two', 'resolve')
+
+    let list = Array.from(history)
+
+    expect(list.map(i => i.type)).toEqual(['$start.1', 'one', 'two'])
+  })
+
+  it('works with for...of', function() {
+    let history = new History({ maxHistory: Infinity })
+
+    history.append('one', 'resolve')
+    history.append('two', 'resolve')
+
+    let list = []
+
+    for (var action of history) {
+      list.push(action.type)
+    }
+
+    expect(list).toEqual(['$start.1', 'one', 'two'])
+  })
+
+  it('works with Promise.all', async function() {
+    let history = new History({ maxHistory: Infinity })
+
+    let one = history.append('one', 'resolve')
+    let two = history.append('two', 'resolve')
+
+    let promise = Promise.all(history)
+
+    one.resolve()
+    two.resolve()
+
+    // Basically, this should complete
+    await promise.then(() => {
+      for (var action of history) {
+        expect(action).toHaveStatus('resolve')
+      }
+    })
+  })
+
+  it('works with Observable.of', function() {
+    let history = new History({ maxHistory: Infinity })
+
+    let one = history.append('one', 'resolve')
+    let two = history.append('two', 'resolve')
+    let complete = jest.fn()
+
+    Observable.of(history).subscribe({ complete })
+
+    one.resolve()
+    two.resolve()
+
+    expect(complete).toHaveBeenCalled()
+  })
+})

--- a/test/unit/history/map.test.js
+++ b/test/unit/history/map.test.js
@@ -6,12 +6,12 @@ describe('History::map', function() {
   it('provides the index', function() {
     const history = new History({ maxHistory: Infinity })
 
-    history.append(action, 'resolve')
-    history.append(action, 'resolve')
-    history.append(action, 'resolve')
+    history.append('one', 'resolve')
+    history.append('two', 'resolve')
+    history.append('three', 'resolve')
 
     let result = history.map((action, i) => i)
 
-    expect(result).toEqual([0, 1, 2, 3])
+    expect(result).toEqual([0, 1, 2])
   })
 })

--- a/test/unit/history/map.test.js
+++ b/test/unit/history/map.test.js
@@ -1,0 +1,17 @@
+import History from '../../../src/history'
+
+describe('History::map', function() {
+  const action = n => n
+
+  it('provides the index', function() {
+    const history = new History({ maxHistory: Infinity })
+
+    history.append(action, 'resolve')
+    history.append(action, 'resolve')
+    history.append(action, 'resolve')
+
+    let result = history.map((action, i) => i)
+
+    expect(result).toEqual([0, 1, 2, 3])
+  })
+})

--- a/test/unit/history/updater.test.js
+++ b/test/unit/history/updater.test.js
@@ -59,7 +59,7 @@ describe('History updater', function() {
 
     history.on('release', handler)
 
-    history.append('action').resolve()
+    history.append('one').resolve()
 
     await history.wait()
 


### PR DESCRIPTION
This commit implements the iterator interface for history. This is important for interoperability with other libraries: specifically Observables.

```
// Enumerate over history
for (var action of repo.history) {
  console.log(action)
}

// Or quickly build an array from history
let activeBranch = Array.from(repo.history)

// Or wait for all history to finish
Observable.of(repo.history).subscribe({ next, error, complete })
```