### PR TITLE
Cache domain handlers when possible

### DIFF
--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -6,8 +6,13 @@
  */
 
 type Snapshot = {
+  // The last state the snapshot was dispatched with. This is used
+  // to memoize domain handlers when possible.
   last: *,
+  // The next state for the snapshot. The outcome of `updateSnapshot`.
   next: *,
+  // Last known status of the action associated with this snapshot.
   status: Status,
+  // Last known payload of the action associated with this snapshot.
   payload: *
 }

--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -14,7 +14,7 @@ declare type Snapshot = {
   // The next state for the snapshot. The outcome of `updateSnapshot`.
   next: State,
   // Last known status of the action associated with this snapshot.
-  status: Status,
+  status: ?Status,
   // Last known payload of the action associated with this snapshot.
   payload: *
 }

--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -14,7 +14,7 @@ declare type Snapshot = {
   // The next state for the snapshot. The outcome of `updateSnapshot`.
   next: State,
   // Last known status of the action associated with this snapshot.
-  status: ?Status,
+  status: Status,
   // Last known payload of the action associated with this snapshot.
   payload: *
 }

--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -5,12 +5,14 @@
  * @flow
  */
 
-type Snapshot = {
+type State = { [key: string]: * }
+
+declare type Snapshot = {
   // The last state the snapshot was dispatched with. This is used
   // to memoize domain handlers when possible.
-  last: *,
+  last: State,
   // The next state for the snapshot. The outcome of `updateSnapshot`.
-  next: *,
+  next: State,
   // Last known status of the action associated with this snapshot.
   status: Status,
   // Last known payload of the action associated with this snapshot.

--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview A snapshot is a reference to a specific dispatch for
+ * a given action. A microcosm instance maintains a bank of them to
+ * efficiently update state.
+ * @flow
+ */
+
+type Snapshot = {
+  last: *,
+  next: *,
+  status: Status,
+  payload: *
+}

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -85,7 +85,7 @@ class DomainEngine {
     return domain
   }
 
-  dispatch(action: Action, state: Object, snapshot: Object) {
+  dispatch(action: Action, state: Object, snapshot: Snapshot) {
     let handlers = this.register(action)
     let result = state
 

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -92,21 +92,21 @@ class DomainEngine {
     for (var i = 0, len = handlers.length; i < len; i++) {
       var { key, source, handler } = handlers[i]
 
-      var last = get(result, key)
-      var current = get(snapshot.last, key)
+      var base = get(result, key)
+      var head = get(snapshot.last, key)
 
       if (
-        // If the state different
-        last !== current ||
+        // If the reference to the prior state changed
+        base !== head ||
         // Or the payload is different
         action.payload !== snapshot.payload ||
         // or the status is different
         action.status !== snapshot.status
       ) {
-        var next = handler.call(source, last, action.payload)
-
-        result = set(result, key, next)
+        // Yes: recalculate state from the base
+        result = set(result, key, handler.call(source, base, action.payload))
       } else {
+        // No: use the existing snapshot value (memoizing the domain handler)
         result = set(result, key, get(snapshot.next, key))
       }
     }

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -85,7 +85,7 @@ class DomainEngine {
     return domain
   }
 
-  dispatch(state: Object, action: Action): Object {
+  dispatch(action: Action, state: Object, snapshot: Object) {
     let handlers = this.register(action)
     let result = state
 
@@ -93,9 +93,22 @@ class DomainEngine {
       var { key, source, handler } = handlers[i]
 
       var last = get(result, key)
-      var next = handler.call(source, last, action.payload)
+      var current = get(snapshot.last, key)
 
-      result = set(result, key, next)
+      if (
+        // If the state different
+        last !== current ||
+        // Or the payload is different
+        action.payload !== snapshot.payload ||
+        // or the status is different
+        action.status !== snapshot.status
+      ) {
+        var next = handler.call(source, last, action.payload)
+
+        result = set(result, key, next)
+      } else {
+        result = set(result, key, get(snapshot.next, key))
+      }
     }
 
     return result

--- a/src/history.js
+++ b/src/history.js
@@ -278,15 +278,14 @@ class History extends Emitter {
     console.assert(action, 'History should never reconcile ' + typeof action)
 
     let focus = action
-
     while (focus) {
       this._emit('update', focus)
 
       if (focus === this.head) {
         break
-      } else {
-        focus = focus.next
       }
+
+      focus = focus.next
     }
 
     this.archive()

--- a/src/history.js
+++ b/src/history.js
@@ -279,7 +279,9 @@ class History extends Emitter {
 
     let focus = action
     while (focus) {
-      this._emit('update', focus)
+      if (focus.command !== START) {
+        this._emit('update', focus)
+      }
 
       if (focus === this.head) {
         break

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -206,18 +206,12 @@ class Microcosm extends Emitter implements Domain {
    * that, when rolling back to this action, it always has a state value.
    */
   createSnapshot(action: Action) {
-    let state = this.recall(action.parent)
-
-    let snapshot: Snapshot = {
-      last: state,
-      next: state,
+    this.snapshots[action.id] = {
+      last: this.state,
+      next: this.state,
       status: action.status,
       payload: action.payload
     }
-
-    this.snapshots[action.id] = snapshot
-
-    return snapshot
   }
 
   /**
@@ -226,7 +220,7 @@ class Microcosm extends Emitter implements Domain {
   updateSnapshot(action: Action) {
     // Fall back to creating a snapshot if it does not exist in the event
     // an action is in progress while a fork is being created
-    let snap = this.snapshots[action.id] || this.createSnapshot(action)
+    let snap = this.snapshots[action.id]
     let last = this.recall(action.parent)
 
     if (this.parent) {

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -223,7 +223,7 @@ class Microcosm extends Emitter implements Domain {
    */
   createSnapshot(action: Action): Snapshot {
     let snapshot: Snapshot = {
-      last: this.rebase(action),
+      last: EMPTY,
       next: this.state,
       status: null,
       payload: undefined

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -223,7 +223,7 @@ class Microcosm extends Emitter implements Domain {
     let snapshot: Snapshot = {
       last: this.state,
       next: this.state,
-      status: null,
+      status: 'inactive',
       payload: undefined
     }
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -218,8 +218,6 @@ class Microcosm extends Emitter implements Domain {
    * Update the state snapshot for a given action
    */
   updateSnapshot(action: Action) {
-    // Fall back to creating a snapshot if it does not exist in the event
-    // an action is in progress while a fork is being created
     let snap = this.snapshots[action.id]
     let last = this.recall(action.parent)
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -95,7 +95,7 @@ class Microcosm extends Emitter implements Domain {
   initial: Object
   state: Object
   history: History
-  snapshots: { [key: string]: * }
+  snapshots: { [key: string]: Snapshot }
   domains: DomainEngine
   effects: EffectEngine
   changes: CompareTree
@@ -208,7 +208,7 @@ class Microcosm extends Emitter implements Domain {
   createSnapshot(action: Action) {
     let state = this.recall(action.parent)
 
-    let snapshot = {
+    let snapshot: Snapshot = {
       last: state,
       next: state,
       status: action.status,

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -245,7 +245,11 @@ class Microcosm extends Emitter implements Domain {
       snap.next = last
     }
 
-    this.snapshots[action.id] = merge(snap, { last, status: action.status, payload: action.payload })
+    this.snapshots[action.id] = merge(snap, {
+      last,
+      status: action.status,
+      payload: action.payload
+    })
 
     this.state = snap.next
   }

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -17,8 +17,6 @@ import installDevtools from './install-devtools'
 import { RESET, PATCH, ADD_DOMAIN } from './lifecycle'
 import { merge, get, set, update } from './utils'
 
-const EMPTY = {}
-
 /**
  * Options passed into Microcosm always extend from this object. You
  * can override this value to provide additional defaults for your
@@ -105,7 +103,7 @@ class Microcosm extends Emitter implements Domain {
   constructor(preOptions?: ?Object, state?: Object, deserialize?: boolean) {
     super()
 
-    let options = merge(DEFAULTS, this.constructor.defaults, preOptions || EMPTY)
+    let options = merge(DEFAULTS, this.constructor.defaults, preOptions || {})
 
     this.parent = options.parent
 
@@ -192,7 +190,7 @@ class Microcosm extends Emitter implements Domain {
    * Generates the starting state for a Microcosm instance. This is the result of dispatching `getInitialState` to all domains. It is pure; calling this function will not update state.
    */
   getInitialState() {
-    return this.initial == null ? EMPTY : this.initial
+    return this.initial == null ? {} : this.initial
   }
 
   recall(action: ?Action): Object {
@@ -223,7 +221,7 @@ class Microcosm extends Emitter implements Domain {
    */
   createSnapshot(action: Action): Snapshot {
     let snapshot: Snapshot = {
-      last: EMPTY,
+      last: this.state,
       next: this.state,
       status: null,
       payload: undefined
@@ -391,7 +389,7 @@ class Microcosm extends Emitter implements Domain {
    * The default registration method for Microcosms
    */
   register() {
-    return EMPTY
+    return {}
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -218,10 +218,3 @@ export function update(
 
   return set(state, path, next)
 }
-
-/**
- * A couple of methods use identity functions. This avoids duplication.
- */
-export function identity(n: *) {
-  return n
-}

--- a/test/integration/efficiency.test.js
+++ b/test/integration/efficiency.test.js
@@ -80,7 +80,7 @@ describe('Efficiency', function() {
     two.resolve()
     one.resolve()
 
-    expect(handler).toHaveBeenCalledTimes(3)
+    expect(handler).toHaveBeenCalledTimes(2)
   })
 
   it('does not dispatch a change event if nothing changes on the first reconciliation', () => {

--- a/test/integration/nested-actions.test.js
+++ b/test/integration/nested-actions.test.js
@@ -23,6 +23,7 @@ describe('When pushing actions inside of another action', function() {
         expect(repo).toHaveState('data.focus', true)
 
         repo.push(focuser, false)
+        console.log('After push', repo.state)
 
         expect(repo).toHaveState('data.count', 2)
         expect(repo).toHaveState('data.focus', false)

--- a/test/integration/nested-actions.test.js
+++ b/test/integration/nested-actions.test.js
@@ -23,7 +23,6 @@ describe('When pushing actions inside of another action', function() {
         expect(repo).toHaveState('data.focus', true)
 
         repo.push(focuser, false)
-        console.log('After push', repo.state)
 
         expect(repo).toHaveState('data.count', 2)
         expect(repo).toHaveState('data.focus', false)

--- a/test/integration/reexecuting-domain-handlers.test.js
+++ b/test/integration/reexecuting-domain-handlers.test.js
@@ -51,9 +51,6 @@ describe('Re-executing domain handlers', function() {
     let addOne = jest.fn((count, n) => count + n)
     let addTwo = jest.fn((count, n) => count + n)
 
-    addOne.displayName = 'addOne'
-    addTwo.displayName = 'addTwo'
-
     repo.addDomain('counterOne', {
       getInitialState() {
         return 0
@@ -84,9 +81,100 @@ describe('Re-executing domain handlers', function() {
 
     one.resolve(1)
 
+    expect(repo.state).toEqual({ counterOne: 3, counterTwo: 3 })
+
     expect(addOne).toHaveBeenCalledTimes(3)
     expect(addTwo).toHaveBeenCalledTimes(3)
+  })
 
-    expect(repo.state).toEqual({ counterOne: 3, counterTwo: 3 })
+  it('does not call the same domain handler again for the same update state', function() {
+    let repo = new Microcosm()
+
+    let addOne = jest.fn((count, n) => count + n)
+    let addTwo = jest.fn((count, n) => count + n)
+
+    repo.addDomain('counterOne', {
+      getInitialState() {
+        return 0
+      },
+      register() {
+        return {
+          addOne: {
+            update: addOne
+          }
+        }
+      }
+    })
+
+    repo.addDomain('counterTwo', {
+      getInitialState() {
+        return 0
+      },
+      register() {
+        return { addTwo }
+      }
+    })
+
+    let one = repo.append('addOne')
+
+    repo.push('addTwo', 2)
+
+    one.update(1)
+    one.update(2)
+    one.update(3)
+
+    expect(addOne).toHaveBeenCalledTimes(3) // once for each update
+
+    expect(addTwo).toHaveBeenCalledTimes(1) // once for resolve
+
+    expect(repo.state).toEqual({ counterOne: 3, counterTwo: 2 })
+  })
+
+  it('does not call the same domain handler when a fork listens to the same action from a different key', function() {
+    let parent = new Microcosm()
+
+    let addOne = jest.fn((count, n) => count + n)
+    let addTwo = jest.fn((count, n) => count + n)
+
+    parent.addDomain('counterOne', {
+      getInitialState() {
+        return 0
+      },
+      addCounterOne() {
+        return addOne(...arguments)
+      },
+      register() {
+        return { test: this.addCounterOne }
+      }
+    })
+
+    let child = parent.fork()
+
+    child.addDomain('counterTwo', {
+      getInitialState() {
+        return 0
+      },
+      addCounterTwo: function() {
+        return addTwo(...arguments)
+      },
+      register() {
+        return { test: this.addCounterTwo }
+      }
+    })
+
+    let one = parent.append('test')
+
+    parent.push('test', 2)
+
+    one.resolve(1)
+
+    expect(parent).toHaveState('counterOne', 3)
+    expect(parent).not.toHaveState('counterTwo')
+
+    expect(child).toHaveState('counterOne', 3)
+    expect(child).toHaveState('counterTwo', 3)
+
+    expect(addOne).toHaveBeenCalledTimes(3)
+    expect(addTwo).toHaveBeenCalledTimes(3)
   })
 })

--- a/test/integration/reexecuting-domain-handlers.test.js
+++ b/test/integration/reexecuting-domain-handlers.test.js
@@ -70,7 +70,6 @@ describe('Re-executing domain handlers', function() {
 
     let child = parent.fork()
 
-    counterTwoCalls += 1
     child.addDomain('counterTwo', {
       getInitialState() {
         return 0

--- a/test/integration/reexecuting-domain-handlers.test.js
+++ b/test/integration/reexecuting-domain-handlers.test.js
@@ -1,10 +1,3 @@
-/**
- * This test covers a bug where the state gets out of sync when an
- * action is pushed within another action. We first encountered this
- * on a project where we wanted to remove a "focused" state when saving
- * data using another action.
- */
-
 import Microcosm from '../../src/microcosm'
 
 describe('Re-executing domain handlers', function() {

--- a/test/integration/reexecuting-domain-handlers.test.js
+++ b/test/integration/reexecuting-domain-handlers.test.js
@@ -1,0 +1,92 @@
+/**
+ * This test covers a bug where the state gets out of sync when an
+ * action is pushed within another action. We first encountered this
+ * on a project where we wanted to remove a "focused" state when saving
+ * data using another action.
+ */
+
+import Microcosm from '../../src/microcosm'
+
+describe('Re-executing domain handlers', function() {
+  it('does not call the same domain handler twice if it would result in no change', function() {
+    let repo = new Microcosm()
+
+    let addOne = jest.fn((count, n) => count + n)
+    let addTwo = jest.fn((count, n) => count + n)
+
+    repo.addDomain('counterOne', {
+      getInitialState() {
+        return 0
+      },
+      register() {
+        return { addOne }
+      }
+    })
+
+    repo.addDomain('counterTwo', {
+      getInitialState() {
+        return 0
+      },
+      register() {
+        return { addTwo }
+      }
+    })
+
+    let one = repo.append('addOne')
+
+    repo.push('addTwo', 2)
+
+    one.resolve(1)
+
+    expect(addOne).toHaveBeenCalledTimes(1)
+
+    expect(addTwo).toHaveBeenCalledTimes(1)
+
+    expect(repo.state).toEqual({ counterOne: 1, counterTwo: 2 })
+  })
+
+  it('does not call the same domain handler twice when two domains listen to the same action from a different key', function() {
+    let repo = new Microcosm()
+
+    let addOne = jest.fn((count, n) => count + n)
+    let addTwo = jest.fn((count, n) => count + n)
+
+    addOne.displayName = 'addOne'
+    addTwo.displayName = 'addTwo'
+
+    repo.addDomain('counterOne', {
+      getInitialState() {
+        return 0
+      },
+      addCounterOne() {
+        return addOne(...arguments)
+      },
+      register() {
+        return { test: this.addCounterOne }
+      }
+    })
+
+    repo.addDomain('counterTwo', {
+      getInitialState() {
+        return 0
+      },
+      addCounterTwo: function() {
+        return addTwo(...arguments)
+      },
+      register() {
+        return { test: this.addCounterTwo }
+      }
+    })
+
+    let one = repo.append('test')
+
+    repo.push('test', 2)
+
+    one.resolve(1)
+
+    expect(addOne).toHaveBeenCalledTimes(3)
+    expect(addTwo).toHaveBeenCalledTimes(3)
+
+    expect(repo.state).toEqual({ counterOne: 3, counterTwo: 3 })
+  })
+})

--- a/test/integration/rollbacks.test.js
+++ b/test/integration/rollbacks.test.js
@@ -24,8 +24,10 @@ describe('rollbacks', function() {
 
       register() {
         return {
-          [send.open]: this.addLoading,
-          [send.done]: this.add
+          [send]: {
+            open: this.addLoading,
+            done: this.add
+          }
         }
       }
     })

--- a/test/integration/snapshots-in-forks.test.js
+++ b/test/integration/snapshots-in-forks.test.js
@@ -1,0 +1,44 @@
+import Microcosm from '../../src/microcosm'
+
+describe('Snapshots', function() {
+  it('forks accommodate actions that were pushed before the parent was forked', function() {
+    let parent = new Microcosm()
+
+    let action = parent.append('add', 'open')
+
+    parent.addDomain('top', {
+      getInitialState() {
+        return 0
+      },
+      add(count, n) {
+        return count + n
+      },
+      register() {
+        return {
+          add: this.add
+        }
+      }
+    })
+
+    let child = parent.fork()
+
+    child.addDomain('bottom', {
+      getInitialState() {
+        return 0
+      },
+      add(count, n) {
+        return count + n
+      },
+      register() {
+        return {
+          add: this.add
+        }
+      }
+    })
+
+    action.resolve(2)
+
+    expect(parent).toHaveState('top', 2)
+    expect(child).toHaveState('bottom', 2)
+  })
+})

--- a/test/unit/microcosm/addDomain.test.js
+++ b/test/unit/microcosm/addDomain.test.js
@@ -75,5 +75,24 @@ describe('Microcosm::addDomain', function() {
       expect(repo).not.toHaveState('b')
       expect(fork).toHaveState('b', 2)
     })
+
+    it('adding a domain to a child does not modify a parent', function() {
+      let repo = new Microcosm()
+      let fork = repo.fork()
+
+      repo.addDomain('a', {
+        getInitialState() {
+          return 0
+        }
+      })
+
+      fork.addDomain('b', {
+        getInitialState() {
+          return 2
+        }
+      })
+
+      expect(repo).not.toHaveState('b')
+    })
   })
 })


### PR DESCRIPTION
This commit changes the way we store snapshots such that they have context into their last operation. This lets us memoize domain handlers. Basically:

1. Is the prior snapshot value the same?
2. Is the prior action status the same?
3. Is the prior action payload the same?

If so, don't invoke the domain handler again!

Testing this in the wild, this has cut extra domain handler invocation for lots of async tasks by about 30%. Pretty neat.

I also believe that we could use this new approach for reporting in the developer tools. We _could_ eventually store each of these snapshots as a diff.

Additionally, if we were to support sub-domains #184, this caching would become more and more powerful as your key paths became more specific. Breaking up complicated state management would get faster.