### PR TITLE
Do not return undefined when getting null with no fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Microcosm ships with ES6 and UMD bundles
 - Domains and Effects can implement a `defaults` static object to
   provide default setup options.
+- Do not return undefined when using `get` to retrieve a null value
+  without a fallback.
 
 # 12.9.0
 

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -93,8 +93,8 @@ class DomainEngine {
     for (var i = 0, len = handlers.length; i < len; i++) {
       var { key, source, handler } = handlers[i]
 
-      var base = get(result, key)
-      var head = get(snapshot.last, key)
+      var base = get(result, key, null)
+      var head = get(snapshot.last, key, null)
 
       if (
         // If the reference to the prior state changed

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,11 @@ export function get(object: ?Object, keyPath: *, fallback?: *) {
     value = value[path[i]]
   }
 
-  return value == null ? fallback : value
+  if (value == null) {
+    return arguments.length <= 2 ? value : fallback
+  }
+
+  return value
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,7 @@ export function get(object: ?Object, keyPath: *, fallback?: *) {
     value = value[path[i]]
   }
 
-  if (value == null) {
+  if (value === undefined || value === null) {
     return arguments.length <= 2 ? value : fallback
   }
 

--- a/test/unit/compare-tree/compare-tree.test.js
+++ b/test/unit/compare-tree/compare-tree.test.js
@@ -250,7 +250,7 @@ describe('CompareTree', function() {
         meta: { selected: true }
       })
 
-      expect(handler).toHaveBeenCalledWith(undefined)
+      expect(handler).toHaveBeenCalledWith(null)
     })
 
     it('the root node does not get called twice if subscribing to two children', function() {

--- a/test/unit/utils/get.test.js
+++ b/test/unit/utils/get.test.js
@@ -32,6 +32,18 @@ describe('Utils.get', function() {
     expect(fallback).toBe(true)
   })
 
+  it('returns the value if there is no fallback and the value is null', function() {
+    let value = get({ prop: null }, 'prop')
+
+    expect(value).toBe(null)
+  })
+
+  it('returns the value if there is no fallback and the value is undefined', function() {
+    let value = get({ prop: undefined }, 'prop')
+
+    expect(value).toBe(undefined)
+  })
+
   it('returns the fallback if the key and fallback are null', function() {
     let fallback = get(null, null, true)
 


### PR DESCRIPTION
Just got hit by this nasty bug. Getting `null` out of an object was returning undefined because the loose null check returned an undefined fallback:

```
get({ prop: null }, 'prop') // undefined, but should be null
```

This is because we trigger the fallback on null. The problem is that a value is present here, so we should respect it when there is no fallback.