### PR TITLE
Make register object optional

### DIFF
--- a/flow/domain.js
+++ b/flow/domain.js
@@ -46,7 +46,7 @@ declare interface Domain {
    * Returns an object mapping actions to methods on the domain. This is the
    * communication point between a domain and the rest of the system.
    */
-  register(): {
+  register(): ?{
     [key: string | Function]: (last?: *, next?: *) => *
   }
 }

--- a/src/get-registration.js
+++ b/src/get-registration.js
@@ -17,8 +17,13 @@ export const STATUSES = {
 /**
  * Gets any registrations that match a given command and status.
  */
-function getRegistration(pool: Object, command: Tagged, status: Status) {
+function getRegistration(pool: ?Object, command: Tagged, status: Status) {
   let answer = null
+
+  if (pool == null) {
+    return answer
+  }
+
   let alias = STATUSES[status]
 
   console.assert(alias, 'Invalid action status ' + status)

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -394,7 +394,7 @@ class Microcosm extends Emitter implements Domain {
    * The default registration method for Microcosms
    */
   register() {
-    return {}
+    return null
   }
 
   /**


### PR DESCRIPTION
Makes returning an object optional. Cuts an object allocation on every new action push because we don't need to return an object in the default Microcosm register method.