### PR TITLE
Warn when pushing an action to a torn down Microcosm

### DIFF
--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -100,7 +100,7 @@ class Microcosm extends Emitter implements Domain {
   effects: EffectEngine
   changes: CompareTree
   options: Object
-  active: Boolean
+  active: boolean
 
   constructor(preOptions?: ?Object, state?: Object, deserialize?: boolean) {
     super()

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -100,6 +100,7 @@ class Microcosm extends Emitter implements Domain {
   effects: EffectEngine
   changes: CompareTree
   options: Object
+  active: Boolean
 
   constructor(preOptions?: ?Object, state?: Object, deserialize?: boolean) {
     super()
@@ -117,6 +118,7 @@ class Microcosm extends Emitter implements Domain {
     this.domains = new DomainEngine(this)
     this.effects = new EffectEngine(this)
     this.changes = new CompareTree(this.state)
+    this.active = true
 
     // History moves through a set lifecycle. As that lifecycle occurs,
     // save snapshots of new state:
@@ -330,6 +332,13 @@ class Microcosm extends Emitter implements Domain {
 
     coroutine(action, command, params, this)
 
+    console.assert(
+      this.active,
+      'Pushed "%s" action, however this Microcosm has been shutdown. ' +
+      "It's possible that an event subscription was not cleaned up.",
+      action
+    )
+
     return action
   }
 
@@ -458,6 +467,8 @@ class Microcosm extends Emitter implements Domain {
    * Close out a Microcosm
    */
   shutdown() {
+    this.active = false
+
     // Call teardown on the Microcosm
     this.teardown()
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -335,7 +335,7 @@ class Microcosm extends Emitter implements Domain {
     console.assert(
       this.active,
       'Pushed "%s" action, however this Microcosm has been shutdown. ' +
-      "It's possible that an event subscription was not cleaned up.",
+        "It's possible that an event subscription was not cleaned up.",
       action
     )
 

--- a/test/unit/microcosm/push.test.js
+++ b/test/unit/microcosm/push.test.js
@@ -146,4 +146,15 @@ describe('Microcosm::push', function() {
       expect(left.state.color).toEqual('blue')
     })
   })
+
+  it.dev('warns when pushing an action from a torn down Microcosm', function() {
+    let repo = new Microcosm()
+
+    repo.shutdown()
+
+    expect(repo.prepare('test')).toThrow(
+      'Pushed "test" action, however this Microcosm has been shutdown. ' +
+        "It's possible that an event subscription was not cleaned up."
+    )
+  })
 })

--- a/test/unit/microcosm/shutdown.test.js
+++ b/test/unit/microcosm/shutdown.test.js
@@ -4,7 +4,13 @@ describe('Microcosm::shutdown', function() {
   it('removes all listeners', function() {
     const repo = new Microcosm()
 
-    repo.addDomain('colors', {})
+    repo.addDomain('colors', {
+      register() {
+        return {
+          'setColor': (a, b) => b
+        }
+      }
+    })
 
     const listener = jest.fn()
 
@@ -12,7 +18,7 @@ describe('Microcosm::shutdown', function() {
 
     repo.shutdown()
 
-    repo.patch({ colors: 'blue' })
+    repo.append('setColor').resolve('blue')
 
     expect(listener).not.toHaveBeenCalled()
   })
@@ -35,7 +41,8 @@ describe('Microcosm::shutdown', function() {
 
     repo.push('test')
     repo.shutdown()
-    repo.push('test')
+
+    repo.append('test', 'resolve')
 
     expect(register).toHaveBeenCalledTimes(1)
   })

--- a/test/unit/microcosm/shutdown.test.js
+++ b/test/unit/microcosm/shutdown.test.js
@@ -7,7 +7,7 @@ describe('Microcosm::shutdown', function() {
     repo.addDomain('colors', {
       register() {
         return {
-          'setColor': (a, b) => b
+          setColor: (a, b) => b
         }
       }
     })


### PR DESCRIPTION
This PR makes it so that we warn when pushing to a torn down microcosm. This should only happen if an event subscription hasn't been properly torn down when a Presenter unmounts.

Fixes #391 