### PR TITLE
Pass the domain key to construction options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog 
 
+## Edge
+
+- Domain::setup and constructors receive the key they were mounted at via
+  `options.key`.
+
 # 12.11.0
 
 - Removed string `ref` in ActionForm, avoiding some edge cases and
@@ -9,12 +14,6 @@
 - register() can return null
 - Pass `context` to ActionForm constructor, fixing a bug with context
 - Use buble instead of babel for production builds, decreasing build size
-
-## Edge
-
-- Domain::setup and constructors receive the key they were mounted at via
-  `options.key`.
-
 
 ## 12.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@
 - Pass `context` to ActionForm constructor, fixing a bug with context
 - Use buble instead of babel for production builds, decreasing build size
 
-# 12.10.0
+## Edge
+
+- Domain::setup and constructors receive the key they were mounted at via
+  `options.key`.
+
+
+## 12.10.0
 
 - Microcosm ships with ES6 and UMD bundles
 - Domains and Effects can implement a `defaults` static object to
@@ -19,7 +25,7 @@
   without a fallback.
 - `repo.append(action, state)` should reconcile history
 
-# 12.9.0
+## 12.9.0
 
 - Added new `repo.parallel` method. This returns an action that
   represents a group of actions processing in parallel.

--- a/docs/api/domains.md
+++ b/docs/api/domains.md
@@ -133,6 +133,22 @@ var Planets = {
 Setup runs right after a domain is added to a Microcosm, but before it runs
 getInitialState. This is useful for one-time setup instructions.
 
+Options are passed from the second argument of
+`repo.addDomain`. Additionally, `options.key` indicates the key where
+the domain was mounted:
+
+```javascript
+let repo = new Microcosm()
+
+class Planets {
+  setup(repo, options) {
+    console.log(options.key) // "planets"
+  }
+}
+
+repo.addDomain('planets', Planets)
+```
+
 ### `teardown(repo)`
 
 Runs whenever a Microcosm is torn down. This usually happens when a

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -66,7 +66,12 @@ class DomainEngine {
   }
 
   add(key: string | KeyPath, config: *, options?: Object) {
-    let deepOptions = merge(this.repo.options, config.defaults, { key }, options)
+    let deepOptions = merge(
+      this.repo.options,
+      config.defaults,
+      { key },
+      options
+    )
     let domain: Domain = createOrClone(config, deepOptions, this.repo)
     let keyPath: KeyPath = castPath(key)
 

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -66,7 +66,7 @@ class DomainEngine {
   }
 
   add(key: string | KeyPath, config: *, options?: Object) {
-    let deepOptions = merge(this.repo.options, config.defaults, options)
+    let deepOptions = merge(this.repo.options, config.defaults, { key }, options)
     let domain: Domain = createOrClone(config, deepOptions, this.repo)
     let keyPath: KeyPath = castPath(key)
 

--- a/test/unit/domain/construction.test.js
+++ b/test/unit/domain/construction.test.js
@@ -112,18 +112,12 @@ describe('Domain construction', function() {
   it('passes the mount key to options', function() {
     expect.assertions(1)
 
-    const repo = new Microcosm({ count: 0 })
+    const repo = new Microcosm()
 
-    class Counter {
-      static defaults = {
-        count: 1
-      }
-
+    repo.addDomain('count', {
       setup(repo, options) {
         expect(options.key).toBe('count')
       }
-    }
-
-    repo.addDomain('count', Counter, { count: 2 })
+    })
   })
 })

--- a/test/unit/domain/construction.test.js
+++ b/test/unit/domain/construction.test.js
@@ -108,4 +108,22 @@ describe('Domain construction', function() {
 
     repo.addDomain('count', Counter, { count: 2 })
   })
+
+  it('passes the mount key to options', function() {
+    expect.assertions(1)
+
+    const repo = new Microcosm({ count: 0 })
+
+    class Counter {
+      static defaults = {
+        count: 1
+      }
+
+      setup(repo, options) {
+        expect(options.key).toBe('count')
+      }
+    }
+
+    repo.addDomain('count', Counter, { count: 2 })
+  })
 })


### PR DESCRIPTION
This PR adds the mount point to the options passed to domains. It can be accessed from `options.key` in `setup` and the constructor.

```javascript
let repo = new Microcosm()

class Planets {
  setup(repo, options) {
    console.log(options.key) // "planets"
  }
}

repo.addDomain('planets', Planets)
```

Fixes https://github.com/vigetlabs/microcosm/issues/396. 