### PR TITLE
Add subscribe method to action to abbreviate addons

### DIFF
--- a/packages/microcosm-preact/src/action-button.js
+++ b/packages/microcosm-preact/src/action-button.js
@@ -1,9 +1,6 @@
 import { h, Component } from 'preact'
 import { Action, merge } from 'microcosm'
 
-/* istanbul ignore next */
-const identity = () => {}
-
 class ActionButton extends Component {
   constructor(props, context) {
     super(props, context)
@@ -16,12 +13,7 @@ class ActionButton extends Component {
     let action = this.send(this.props.action, this.props.value)
 
     if (action && action instanceof Action) {
-      action
-        .onOpen(this.props.onOpen)
-        .onUpdate(this.props.onUpdate)
-        .onCancel(this.props.onCancel)
-        .onDone(this.props.onDone)
-        .onError(this.props.onError)
+      action.subscribe(this.props)
     }
 
     if (this.props.onClick) {
@@ -50,10 +42,6 @@ class ActionButton extends Component {
 
     return h(this.props.tag, props)
   }
-}
-
-ActionButton.contextTypes = {
-  send: identity
 }
 
 ActionButton.defaultProps = {

--- a/packages/microcosm-preact/src/action-form.js
+++ b/packages/microcosm-preact/src/action-form.js
@@ -2,9 +2,6 @@ import { h, Component } from 'preact'
 import { Action, merge } from 'microcosm'
 import serialize from 'form-serialize'
 
-/* istanbul ignore next */
-const identity = () => {}
-
 class ActionForm extends Component {
   constructor(props, context) {
     super(props, context)
@@ -44,20 +41,11 @@ class ActionForm extends Component {
     let action = this.send(this.props.action, params)
 
     if (action && action instanceof Action) {
-      action
-        .onOpen(this.props.onOpen)
-        .onUpdate(this.props.onUpdate)
-        .onCancel(this.props.onCancel)
-        .onDone(this.props.onDone)
-        .onError(this.props.onError)
+      action.subscribe(this.props)
     }
 
     this.props.onSubmit(event, action)
   }
-}
-
-ActionForm.contextTypes = {
-  send: identity
 }
 
 ActionForm.defaultProps = {

--- a/packages/microcosm-preact/test/unit/action-button.test.js
+++ b/packages/microcosm-preact/test/unit/action-button.test.js
@@ -1,7 +1,29 @@
 import { h } from 'preact'
 import { mount } from '../helpers'
-import ActionButton from '../../src/action-button'
+import { ActionButton, Presenter } from '../../src/index'
 import { Action } from 'microcosm'
+
+describe('context', function() {
+  it('collects send from a presenter', function() {
+    expect.assertions(1)
+
+    const test = jest.fn()
+
+    class TestCase extends Presenter {
+      intercept() {
+        return { test }
+      }
+
+      render() {
+        return <ActionButton action="test" />
+      }
+    }
+
+    mount(<TestCase />).click()
+
+    expect(test).toHaveBeenCalled()
+  })
+})
 
 describe('actions', function() {
   it('passes the value property as parameters into the action', function() {

--- a/packages/microcosm-preact/test/unit/action-form.test.js
+++ b/packages/microcosm-preact/test/unit/action-form.test.js
@@ -1,7 +1,29 @@
 import { h } from 'preact'
 import { mount } from '../helpers'
 import { Action } from 'microcosm'
-import ActionForm from '../../src/action-form'
+import { ActionForm, Presenter } from '../../src'
+
+describe('context', function() {
+  it('collects send from presenter', function() {
+    expect.assertions(1)
+
+    const test = jest.fn()
+
+    class TestCase extends Presenter {
+      intercept() {
+        return { test }
+      }
+
+      render() {
+        return <ActionForm action="test" />
+      }
+    }
+
+    mount(<TestCase />).dispatchEvent(new Event('submit'))
+
+    expect(test).toHaveBeenCalled()
+  })
+})
 
 describe('callbacks', function() {
   it('executes onDone when that action completes', function() {

--- a/packages/microcosm-preact/test/unit/with-send.test.js
+++ b/packages/microcosm-preact/test/unit/with-send.test.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact'
 import { mount } from '../helpers'
-import withSend from '../../src/with-send'
+import { withSend } from '../../src'
 
 it('exposes the wrapped component as a static property', function() {
   const Button = function({ send }) {

--- a/packages/microcosm/src/action.js
+++ b/packages/microcosm/src/action.js
@@ -53,7 +53,7 @@ class Action extends Emitter {
     this.revisions = []
 
     if (status) {
-      this.setState(status)
+      this._setState(status)
     }
   }
 
@@ -62,23 +62,23 @@ class Action extends Emitter {
   }
 
   get open(): ActionUpdater {
-    return this.setState.bind(this, 'open')
+    return this._setState.bind(this, 'open')
   }
 
   get update(): ActionUpdater {
-    return this.setState.bind(this, 'update')
+    return this._setState.bind(this, 'update')
   }
 
   get resolve(): ActionUpdater {
-    return this.setState.bind(this, 'resolve')
+    return this._setState.bind(this, 'resolve')
   }
 
   get reject(): ActionUpdater {
-    return this.setState.bind(this, 'reject')
+    return this._setState.bind(this, 'reject')
   }
 
   get cancel(): ActionUpdater {
-    return this.setState.bind(this, 'cancel')
+    return this._setState.bind(this, 'cancel')
   }
 
   onOpen(callback: Callback, scope?: Object): this {
@@ -121,6 +121,28 @@ class Action extends Emitter {
     }
 
     return this
+  }
+
+  subscribe(callbacks: Object, scope: *) {
+    if (callbacks.onOpen) {
+      this.onOpen(callbacks.onOpen, scope)
+    }
+
+    if (callbacks.onUpdate) {
+      this.onUpdate(callbacks.onUpdate, scope)
+    }
+
+    if (callbacks.onCancel) {
+      this.onCancel(callbacks.onCancel, scope)
+    }
+
+    if (callbacks.onDone) {
+      this.onDone(callbacks.onDone, scope)
+    }
+
+    if (callbacks.onError) {
+      this.onError(callbacks.onError, scope)
+    }
   }
 
   /**
@@ -251,7 +273,7 @@ class Action extends Emitter {
     }
   }
 
-  setState(status: Status, payload: mixed) {
+  _setState(status: Status, payload: mixed) {
     if (this.complete) {
       return this
     }

--- a/packages/microcosm/src/addons/action-button.js
+++ b/packages/microcosm/src/addons/action-button.js
@@ -5,10 +5,7 @@
 import React from 'react'
 import { Action, merge } from '../index'
 
-/* istanbul ignore next */
 const identity = n => n
-/* istanbul ignore next */
-const noop = () => {}
 
 type Props = {
   action: *,
@@ -43,25 +40,20 @@ class ActionButton extends React.PureComponent<Props> {
   }
 
   click(event: Event) {
-    let payload = this.props.prepare(this.props.value, event)
-    let action = null
+    const { action, onClick, prepare, value } = this.props
 
-    if (this.props.action) {
-      action = this.send(this.props.action, payload)
+    let params = prepare(value, event)
+    let result = null
 
-      if (action && action instanceof Action) {
-        action
-          .onOpen(this.props.onOpen)
-          .onUpdate(this.props.onUpdate)
-          .onCancel(this.props.onCancel)
-          .onDone(this.props.onDone)
-          .onError(this.props.onError)
+    if (action) {
+      result = this.send(action, params)
+
+      if (result && result instanceof Action) {
+        result.subscribe(this.props)
       }
     }
 
-    if (this.props.onClick) {
-      this.props.onClick(event, action)
-    }
+    onClick(event, action)
   }
 
   render() {
@@ -87,7 +79,7 @@ class ActionButton extends React.PureComponent<Props> {
 }
 
 ActionButton.contextTypes = {
-  send: noop
+  send: () => {}
 }
 
 ActionButton.defaultProps = {

--- a/packages/microcosm/test/addons/action-button.test.js
+++ b/packages/microcosm/test/addons/action-button.test.js
@@ -89,6 +89,24 @@ describe('callbacks', function() {
     expect(onUpdate).toHaveBeenCalledWith('loading')
   })
 
+  it('executes onCancel when that action completes', function() {
+    let repo = new Microcosm()
+    let onCancel = jest.fn()
+
+    let button = mount(
+      <ActionButton action="test" onCancel={n => onCancel(n)} />,
+      {
+        context: {
+          send: () => repo.append(n => n).cancel('nevermind')
+        }
+      }
+    )
+
+    button.simulate('click')
+
+    expect(onCancel).toHaveBeenCalledWith('nevermind')
+  })
+
   it('does not execute onDone if not given an action', function() {
     let onDone = jest.fn()
 

--- a/packages/microcosm/test/addons/action-form.test.js
+++ b/packages/microcosm/test/addons/action-form.test.js
@@ -82,6 +82,19 @@ describe('callbacks', function() {
   })
 })
 
+describe('action submission', function() {
+  describe('when there is no action', function() {
+    it('does not execute send', function() {
+      const send = jest.fn()
+      const form = mount(<ActionForm send={send} />)
+
+      form.simulate('submit')
+
+      expect(send).not.toHaveBeenCalled()
+    })
+  })
+})
+
 describe('context', function() {
   it('inherits send from context', function() {
     const repo = new Microcosm()
@@ -135,56 +148,5 @@ describe('manual operation', function() {
     form.instance().submit()
 
     expect(send).toHaveBeenCalled()
-  })
-})
-
-describe('serialization', function() {
-  it('extracts form data', function() {
-    const action = jest.fn()
-
-    const form = mount(
-      <Presenter>
-        <ActionForm action={action}>
-          <input name="text" defaultValue="Hello, world" />
-        </ActionForm>
-      </Presenter>
-    )
-
-    form.simulate('submit')
-
-    expect(action).toHaveBeenCalledWith({ text: 'Hello, world' })
-  })
-
-  it('can preprocess serialized data', function() {
-    const action = jest.fn()
-
-    const prepare = function(params) {
-      params.name = 'BILLY'
-      return params
-    }
-
-    const form = mount(
-      <Presenter>
-        <ActionForm action={action} prepare={prepare}>
-          <input name="name" defaultValue="Billy" />
-        </ActionForm>
-      </Presenter>
-    )
-
-    form.simulate('submit')
-
-    expect(action).toHaveBeenCalledWith({ name: 'BILLY' })
-  })
-
-  it.dev('will not submit an unmounted form', function() {
-    const form = mount(<ActionForm send={jest.fn()} />)
-
-    let instance = form.instance()
-
-    form.unmount()
-
-    expect(function() {
-      instance.submit()
-    }).toThrow(/ActionForm has no form reference and can not submit/)
   })
 })

--- a/packages/microcosm/test/addons/action-form.test.js
+++ b/packages/microcosm/test/addons/action-form.test.js
@@ -4,7 +4,6 @@
 
 import React from 'react'
 import ActionForm from 'microcosm/addons/action-form'
-import Presenter from 'microcosm/addons/presenter'
 import mockSend from '../helpers/mock-send'
 import Microcosm from 'microcosm'
 import { mount } from 'enzyme'


### PR DESCRIPTION
This PR adds a new `subscribe` method for quickly adding a bunch of action callbacks. Long term, this moves actions closer to the Observable interface, but it also cleans up the action form and button pretty nicely.

I also added some tests to gain some missing coverage.