### PR TITLE
Engage Microcosm in layers

### DIFF
--- a/packages/microcosm/test/unit/microcosm/shutdown.test.js
+++ b/packages/microcosm/test/unit/microcosm/shutdown.test.js
@@ -65,6 +65,9 @@ describe('Microcosm::shutdown', function() {
       parent.patch({ color: 'blue' })
 
       expect(parent.state.color).toEqual('blue')
+
+      // Despite not sending out a change, state should be in sync
+      expect(child.state.color).toEqual('blue')
     })
   })
 })


### PR DESCRIPTION
Presenters build a lot of forks. This commit makes it so that most of the overhead of Microcosm is avoided in forks if they do not attach domains or effects.

## Before

```
Conducting fork benchmark...

Count    Setup      Push
-------  ---------  ---------
1,000    12.527ms   27.356ms
10,000   72.586ms   106.089ms
50,000   213.31ms   475.951ms
100,000  390.559ms  775.968ms
```

## After

```
Conducting fork benchmark...

Count    Setup      Push
-------  ---------  --------
1,000    6.894ms    2.48ms
10,000   30.983ms   5.023ms
50,000   147.558ms  19.37ms
100,000  163.918ms  38.091ms
```

