### PR TITLE
Remove ability to reset Microcosm on construction

### DIFF
--- a/packages/microcosm/CHANGELOG.md
+++ b/packages/microcosm/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Moved internal state tree diffing tool to addon. 
 - Removed support for root level domains, forks can not add keys managed by parents. Repos can not add domains to the same key name.
+- Removed feature to instantiate a Microcosm with an initial state using the second argument of the constructor.
 
 ## 12.14.0 (beta)
 

--- a/packages/microcosm/src/action.js
+++ b/packages/microcosm/src/action.js
@@ -85,7 +85,10 @@ class Action extends Emitter {
   }
 
   execute(params: *[]): this {
-    console.assert(Array.isArray(params), 'Action.execute must receive array of arguments.')
+    console.assert(
+      Array.isArray(params),
+      'Action.execute must receive array of arguments.'
+    )
 
     coroutine(this, params, this.origin)
 

--- a/packages/microcosm/src/history.js
+++ b/packages/microcosm/src/history.js
@@ -20,9 +20,9 @@ type HistoryOptions = {
   updater?: (options: Object) => Updater
 }
 
-const DEFAULTS = {
-  maxHistory: 1,
+export const HISTORY_DEFAULTS = {
   batch: false,
+  maxHistory: 1,
   updater: defaultUpdateStrategy
 }
 
@@ -39,7 +39,7 @@ class History extends Emitter {
   constructor(config: HistoryOptions) {
     super()
 
-    let options = merge(DEFAULTS, config)
+    let options = merge(HISTORY_DEFAULTS, config)
 
     this.size = 0
     this.setLimit(options.maxHistory)
@@ -384,7 +384,7 @@ class History extends Emitter {
    * Set the limit of the history object.
    */
   setLimit(limit: number) {
-    this.limit = Math.max(DEFAULTS.maxHistory, limit)
+    this.limit = Math.max(HISTORY_DEFAULTS.maxHistory, limit)
   }
 
   /**

--- a/packages/microcosm/src/microcosm.js
+++ b/packages/microcosm/src/microcosm.js
@@ -6,7 +6,7 @@
 
 import Action from './action'
 import Emitter from './emitter'
-import History from './history'
+import History, { HISTORY_DEFAULTS } from './history'
 import DomainEngine from './domain-engine'
 import EffectEngine from './effect-engine'
 import tag from './tag'
@@ -21,10 +21,10 @@ import { version } from '../package.json'
  * extension of Microcosm.
  */
 const DEFAULTS = {
-  maxHistory: 0,
-  parent: null,
-  batch: false,
-  debug: false
+  batch: HISTORY_DEFAULTS.batch,
+  debug: false,
+  maxHistory: HISTORY_DEFAULTS.maxHistory,
+  parent: null
 }
 
 const EMPTY = {}
@@ -103,7 +103,7 @@ class Microcosm extends Emitter {
   options: Object
   active: boolean
 
-  constructor(preOptions?: ?Object, state?: Object, deserialize?: boolean) {
+  constructor(preOptions?: ?Object) {
     super()
 
     this.options = merge(DEFAULTS, this.constructor.defaults, preOptions || {})
@@ -124,11 +124,6 @@ class Microcosm extends Emitter {
 
     // Microcosm is now ready. Call the setup lifecycle method
     this.setup(this.options)
-
-    // If given state, reset to that snapshot
-    if (state) {
-      this.reset(state, deserialize)
-    }
 
     if (this.options.debug) {
       installDevtools(this)

--- a/packages/microcosm/test/addons/indexes.test.js
+++ b/packages/microcosm/test/addons/indexes.test.js
@@ -167,7 +167,9 @@ describe('memo', function() {
   })
 
   it('the result of processing one memo does not effect another', function() {
-    let repo = new Repo({}, { styles: { color: 'blue' } })
+    let repo = new Repo()
+
+    repo.reset({ styles: { color: 'blue' } })
 
     repo.index('color', 'styles.color', state => state.styles.color)
 

--- a/packages/microcosm/test/unit/microcosm/constructor.test.js
+++ b/packages/microcosm/test/unit/microcosm/constructor.test.js
@@ -1,115 +1,40 @@
 import Microcosm from 'microcosm'
 
 describe('Microcosm constructor', function() {
-  it('can seed initial state', function() {
-    class Repo extends Microcosm {
-      setup() {
-        this.addDomain('foo', {})
-      }
-    }
+  describe('maxHistory option', function() {
+    it('controls history size', function() {
+      const repo = new Microcosm({ maxHistory: 5 })
 
-    const repo = new Repo({}, { foo: 'bar' })
-
-    expect(repo).toHaveState('foo', 'bar')
+      expect(repo.history).toHaveProperty('limit', 5)
+    })
   })
 
-  it('can deserialize the seed', function() {
-    class Repo extends Microcosm {
-      setup() {
-        this.addDomain('foo', {})
+  describe('extending options', function() {
+    it('extends custom defaults with Microcosm defaults', function() {
+      class Repo extends Microcosm {
+        static defaults = {
+          test: true
+        }
       }
-    }
 
-    let raw = JSON.stringify({ foo: 'bar' })
+      let repo = new Repo()
 
-    let repo = new Repo({}, raw, true)
-
-    expect(repo).toHaveState('foo', 'bar')
-  })
-
-  describe('options', function() {
-    describe('parent', function() {
-      it('has no parent by default', function() {
-        expect.assertions(1)
-
-        class Repo extends Microcosm {
-          setup({ parent }) {
-            expect(parent).toEqual(null)
-          }
-        }
-
-        new Repo()
-      })
+      expect(repo.options).toHaveProperty('test', true)
+      expect(repo.options).toHaveProperty('batch', false)
     })
 
-    describe('maxHistory', function() {
-      it('has no history by default', function() {
-        expect.assertions(1)
-
-        class Repo extends Microcosm {
-          setup({ maxHistory }) {
-            expect(maxHistory).toEqual(0)
-          }
+    it('extends custom defaults with passed arguments', function() {
+      class Repo extends Microcosm {
+        static defaults = {
+          test: true
         }
+      }
 
-        new Repo()
-      })
+      let repo = new Repo({ maxHistory: 10, instantiated: true })
 
-      it('controls how many transactions are merged', function() {
-        const repo = new Microcosm({ maxHistory: 5 })
-        const identity = n => n
-
-        repo.push(identity, 1)
-        repo.push(identity, 2)
-        repo.push(identity, 3)
-        repo.push(identity, 4)
-        repo.push(identity, 5)
-
-        expect(repo.history.size).toEqual(5)
-
-        repo.push(identity, 6)
-
-        expect(repo.history.size).toEqual(5)
-        expect(repo.history.root.payload).toEqual(2)
-        expect(repo.history.head.payload).toEqual(6)
-      })
-    })
-
-    describe('extension', function() {
-      it('extends custom defaults with Microcosm defaults', function() {
-        expect.assertions(2)
-
-        class Repo extends Microcosm {
-          static defaults = {
-            test: true
-          }
-
-          setup(options) {
-            expect(options.maxHistory).toBe(0)
-            expect(options.test).toBe(true)
-          }
-        }
-
-        new Repo()
-      })
-
-      it('extends custom defaults with passed arguments', function() {
-        expect.assertions(3)
-
-        class Repo extends Microcosm {
-          static defaults = {
-            test: true
-          }
-
-          setup(options) {
-            expect(options.maxHistory).toBe(10)
-            expect(options.test).toBe(true)
-            expect(options.instantiated).toBe(true)
-          }
-        }
-
-        new Repo({ maxHistory: 10, instantiated: true })
-      })
+      expect(repo.options).toHaveProperty('maxHistory', 10)
+      expect(repo.options).toHaveProperty('test', true)
+      expect(repo.options).toHaveProperty('instantiated', true)
     })
   })
 })

--- a/packages/microcosm/test/unit/microcosm/setup.test.js
+++ b/packages/microcosm/test/unit/microcosm/setup.test.js
@@ -6,8 +6,8 @@ describe('Microcosm::setup', function() {
 
     class Repo extends Microcosm {
       setup(options) {
-        expect(options.foo).toEqual('bar')
-        expect(options.maxHistory).toEqual(0)
+        expect(options).toHaveProperty('foo', 'bar')
+        expect(options).toHaveProperty('maxHistory')
       }
     }
 
@@ -19,7 +19,7 @@ describe('Microcosm::setup', function() {
 
     class Repo extends Microcosm {
       setup(options) {
-        expect(options).toBeDefined()
+        expect(options).toBe(this.options)
       }
     }
 


### PR DESCRIPTION
This commit removes support for the ability to reset state when a Microcosm is created. 

```javascript
let repo = new Repo({}, {
  planets: [ 'earth', 'mars', 'jupiter']
})
```
You mostly see this in tests, and it looks goofy. It's also easy to miss the third argument, which tells Microcosm to deserialize the data (like take string JSON and turn it into an object). Beyond that, there are a couple of other reasons:

1. I only want one way to reset state
2. It can be confusing to look at constructors that include seed data, particularly when deserialized
3. This is part of an effort to reduce some extraneous use cases to improve learnability/useabillity
4. You can't listen to failure (`repo.reset().onError(...)`)

I also took at pass at improving some tests around instantiation options while I was at it.