### PR TITLE
History changeset

### DIFF
--- a/packages/microcosm/src/history.js
+++ b/packages/microcosm/src/history.js
@@ -290,22 +290,9 @@ class History extends Emitter {
     console.assert(this.head, 'History should always have a head node')
     console.assert(action, 'History should never reconcile ' + typeof action)
 
-    let changeset = []
-
-    let focus = action
-    while (focus) {
-      if (focus.command !== START) {
-        changeset.push(focus)
-      }
-
-      if (focus === this.head) {
-        break
-      }
-
-      focus = focus.next
+    if (action.command !== START) {
+      this._emit('change', action, this.head)
     }
-
-    this._emit('change', action, changeset)
 
     this.archive()
 

--- a/packages/microcosm/src/history.js
+++ b/packages/microcosm/src/history.js
@@ -290,10 +290,12 @@ class History extends Emitter {
     console.assert(this.head, 'History should always have a head node')
     console.assert(action, 'History should never reconcile ' + typeof action)
 
+    let changeset = []
+
     let focus = action
     while (focus) {
       if (focus.command !== START) {
-        this._emit('update', focus)
+        changeset.push(focus)
       }
 
       if (focus === this.head) {
@@ -303,9 +305,9 @@ class History extends Emitter {
       focus = focus.next
     }
 
-    this.archive()
+    this._emit('change', action, changeset)
 
-    this._emit('reconcile', action)
+    this.archive()
 
     this.queueRelease()
   }

--- a/packages/microcosm/src/microcosm.js
+++ b/packages/microcosm/src/microcosm.js
@@ -417,6 +417,22 @@ class Microcosm extends Emitter {
       status: action.status,
       payload: action.payload
     }
+
+    return snap.next !== next
+  }
+
+  _reconcileChangeset(action: Action, changeset: Action[]) {
+    for (var i = 0, len = changeset.length; i < len; i++) {
+      var changed = this._updateSnapshot(changeset[i])
+
+      if (changed === false) {
+        break
+      }
+    }
+
+    if (this.effects) {
+      this._dispatchEffect(action)
+    }
   }
 
   _removeSnapshot(action: Action) {
@@ -473,8 +489,8 @@ class Microcosm extends Emitter {
     // When an action is first created
     this.history.on('append', this._createSnapshot, this)
 
-    // When an action snapshot needs updating
-    this.history.on('update', this._updateSnapshot, this)
+    // When an action snapshot range needs updating
+    this.history.on('change', this._reconcileChangeset, this)
 
     // When an action snapshot should be removed
     this.history.on('remove', this._removeSnapshot, this)
@@ -486,9 +502,6 @@ class Microcosm extends Emitter {
     }
 
     this.effects = new EffectEngine(this)
-
-    // When an action changes, it causes a reconcilation
-    this.history.on('reconcile', this._dispatchEffect, this)
   }
 }
 

--- a/packages/microcosm/src/microcosm.js
+++ b/packages/microcosm/src/microcosm.js
@@ -421,17 +421,20 @@ class Microcosm extends Emitter {
     return snap.next !== next
   }
 
-  _reconcileChangeset(action: Action, changeset: Action[]) {
-    for (var i = 0, len = changeset.length; i < len; i++) {
-      var changed = this._updateSnapshot(changeset[i])
+  _updateSnapshotRange(source: Action, end: Action) {
+    let focus = source
+    while (focus) {
+      var changed = this._updateSnapshot(focus)
 
-      if (changed === false) {
+      if (changed === false || focus === end) {
         break
       }
+
+      focus = focus.next
     }
 
     if (this.effects) {
-      this._dispatchEffect(action)
+      this._dispatchEffect(source)
     }
   }
 
@@ -490,7 +493,7 @@ class Microcosm extends Emitter {
     this.history.on('append', this._createSnapshot, this)
 
     // When an action snapshot range needs updating
-    this.history.on('change', this._reconcileChangeset, this)
+    this.history.on('change', this._updateSnapshotRange, this)
 
     // When an action snapshot should be removed
     this.history.on('remove', this._removeSnapshot, this)


### PR DESCRIPTION
**What**

Microcosm determines application state by taking a list of actions (history) and using their results to calculate a new state. When an action changed, History would emit a change event for that action and every action that followed it in this list.

This is a lot of events! Instead, this commit changes the strategy so that it only emits the _range_ of actions; the start and the end.

**Why**

Two reasons:

1. I want to eventually replace event emitters with [observables](https://github.com/tc39/proposal-observable), which more accurately match how actions work. This gets rid of one of those events "update" event, meaning we only need to figure out how to handle "remove", then we can drop the event emitter abstraction.
2. Performance. Because a Microcosm is responsible for iterating through actions instead of history, it can stop processing data when an action results in the same state. For long history chains, and for forks, this can avoid a lot of extra work.