### PR TITLE
Generate snapshots as needed. Remove append event subscription

### DIFF
--- a/packages/microcosm/src/history.js
+++ b/packages/microcosm/src/history.js
@@ -218,8 +218,6 @@ class History extends Emitter {
 
     action.on('change', this.reconcile, this)
 
-    this._emit('append', action)
-
     if (status && action.command !== START) {
       this.reconcile(action)
     }

--- a/packages/microcosm/src/microcosm.js
+++ b/packages/microcosm/src/microcosm.js
@@ -434,10 +434,6 @@ class Microcosm extends Emitter {
 
       focus = focus.next
     }
-
-    if (this.effects) {
-      this._dispatchEffect(source)
-    }
   }
 
   _removeSnapshot(action: Action) {
@@ -509,6 +505,8 @@ class Microcosm extends Emitter {
     }
 
     this.effects = new EffectEngine(this)
+
+    this.history.on('change', this._dispatchEffect, this)
   }
 }
 

--- a/packages/microcosm/test/unit/history/append.test.js
+++ b/packages/microcosm/test/unit/history/append.test.js
@@ -22,17 +22,4 @@ describe('History::append', function() {
     expect(two.parent).toEqual(one)
     expect(three.parent).toEqual(two)
   })
-
-  it('emits an append event with the latest action', function() {
-    expect.assertions(1)
-
-    const repo = new Microcosm()
-    const type = n => n
-
-    repo.history.on('append', function(action) {
-      expect(action.command).toBe(type)
-    })
-
-    repo.append(type)
-  })
 })


### PR DESCRIPTION
**What:**

Microcosm History emits an `append` event that tells its associated Microcosms that it needs to create a snapshot. We can lazily generate snapshots as they are needed, allowing us to get rid of that event.

**Why:**

I am trying to move internals over to [observables](https://github.com/tc39/proposal-observable), which more accurately describe how Microcosms and Actions work. To do that, I need to eliminate a few events, particularly in History.

Basically I'm trying to get everything to work via a single `change` event type, which could eventually be replaced with the observable lifecycle:

1. start (setup microcosm hook)
2. next (change microcosm hook)
3. complete (teardown microcosm hook)
4. error (handled via actions)