### PR TITLE
Batch remove action snapshots

### DIFF
--- a/packages/microcosm/src/lifecycle.js
+++ b/packages/microcosm/src/lifecycle.js
@@ -28,6 +28,4 @@ export const RESET = tag(sandbox.bind(null), '$reset')
 
 export const PATCH = tag(sandbox.bind(null), '$patch')
 
-export const BIRTH = tag('$birth')
-
 export const START = tag('$start')

--- a/packages/microcosm/src/microcosm.js
+++ b/packages/microcosm/src/microcosm.js
@@ -423,12 +423,12 @@ class Microcosm extends Emitter {
     return snap.next !== next
   }
 
-  _updateSnapshotRange(source: Action, end: Action) {
-    let focus = source
+  _updateSnapshotRange(start: Action, stop: Action) {
+    let focus = start
     while (focus) {
       var changed = this._updateSnapshot(focus)
 
-      if (changed === false || focus === end) {
+      if (changed === false || focus === stop) {
         break
       }
 
@@ -436,8 +436,17 @@ class Microcosm extends Emitter {
     }
   }
 
-  _removeSnapshot(action: Action) {
-    delete this.snapshots[action.id]
+  _removeSnapshotRange(start: Action, stop: ?Action) {
+    let focus = start
+    while (focus) {
+      delete this.snapshots[focus.id]
+
+      if (stop != null && focus !== stop) {
+        break
+      }
+
+      focus = focus.parent
+    }
   }
 
   _didChange(): boolean {
@@ -496,7 +505,7 @@ class Microcosm extends Emitter {
     this.history.on('change', this._updateSnapshotRange, this)
 
     // When an action snapshot should be removed
-    this.history.on('remove', this._removeSnapshot, this)
+    this.history.on('remove', this._removeSnapshotRange, this)
   }
 
   _enableEffects() {

--- a/packages/microcosm/src/utils.js
+++ b/packages/microcosm/src/utils.js
@@ -13,7 +13,7 @@ type MixedObject = { [key: string]: mixed }
  */
 let uidStepper = 0
 export function uid(prefix: string): string {
-  return `${prefix}${uidStepper++}`
+  return `${prefix}/${uidStepper++}`
 }
 
 /**

--- a/packages/microcosm/test/unit/history/remove.test.js
+++ b/packages/microcosm/test/unit/history/remove.test.js
@@ -98,16 +98,15 @@ describe('History::remove', function() {
       let repo = new Microcosm({ maxHistory: Infinity })
       let history = repo.history
 
-      repo.append(function one() {}, 'resolve')
+      let one = repo.append(function one() {}, 'resolve')
       repo.append(function two() {}, 'resolve')
       repo.append(function three() {}, 'resolve')
 
       let root = history.root
-      let next = root.next
 
       history.remove(root)
 
-      expect(history.root.id).toBe(next.id)
+      expect(history.root.id).toBe(one.id)
     })
 
     it('updates the active branch', function() {


### PR DESCRIPTION
**What**

This commit changes the way action snapshots are removed such that they are deleted in bulk. Additionally it moves the archive process to after the release process ends, preventing archiving from running multiple times between a release.

It also removes the BIRTH action, which was included to ensure that an action always had a parent. We don't need this. The only time an action will not have a parent is during START.

**Why**

Mostly just a performance optimization that was uncovered with #438 

---

Fixes #440 