### PR TITLE
ActionForm and ActionButton are referenceable via refs

### DIFF
--- a/packages/microcosm/src/addons/action-form.js
+++ b/packages/microcosm/src/addons/action-form.js
@@ -3,6 +3,7 @@
  */
 
 import React from 'react'
+import DOM from 'react-dom'
 import serialize from 'form-serialize'
 import { Action, merge } from '../index'
 import ActionQueue from './action-queue'
@@ -43,19 +44,19 @@ class ActionForm extends React.PureComponent<Props> {
 
     this._onSubmit = this._onSubmit.bind(this)
     this._queue = new ActionQueue(this)
+  }
 
-    this._assignForm = el => {
-      this._form = el
-    }
+  componentDidMount() {
+    this._form = DOM.findDOMNode(this)
   }
 
   componentWillUnmount() {
+    this._form = null
     this._queue.empty()
   }
 
   render() {
     let props = merge(this.props, {
-      ref: this._assignForm,
       onSubmit: this._onSubmit
     })
 

--- a/packages/microcosm/test/addons/action-button.test.js
+++ b/packages/microcosm/test/addons/action-button.test.js
@@ -238,3 +238,27 @@ describe('rendering', function() {
     expect(wrapper.getDOMNode().getAttribute('type')).toBe(null)
   })
 })
+
+describe('refs', function() {
+  it('can be referenced as a ref', function() {
+    let send = jest.fn()
+
+    class Test extends React.Component {
+      render() {
+        return (
+          <ActionButton
+            ref={button => (this.button = button)}
+            action="test"
+            send={send}
+          />
+        )
+      }
+    }
+
+    let el = mount(<Test />)
+
+    el.instance().button.click()
+
+    expect(send).toHaveBeenCalledWith('test', null)
+  })
+})

--- a/packages/microcosm/test/addons/action-form.test.js
+++ b/packages/microcosm/test/addons/action-form.test.js
@@ -168,3 +168,27 @@ describe('manual operation', function() {
     expect(send).toHaveBeenCalled()
   })
 })
+
+describe('refs', function() {
+  it('can be referenced as a ref', function() {
+    let send = jest.fn()
+
+    class Test extends React.Component {
+      render() {
+        return (
+          <ActionForm
+            ref={form => (this.form = form)}
+            action="test"
+            send={send}
+          />
+        )
+      }
+    }
+
+    let el = mount(<Test />)
+
+    el.instance().form.submit()
+
+    expect(send).toHaveBeenCalledWith('test', {})
+  })
+})


### PR DESCRIPTION
This commit ensures that both the ActionForm and ActionButton are
referenceable via refs, and can be submitted programmatically.

Fixes #446