### PR TITLE
Repo.parallel can accept objects

### DIFF
--- a/packages/microcosm/docs/api/actions.md
+++ b/packages/microcosm/docs/api/actions.md
@@ -210,10 +210,38 @@ function getUsers (ids) {
     yield ids.map(id => repo.push(getUser, id))
   }
 }
+
+repo.push(getUsers, [ 1, 2 ])
 ```
 
-If all actions resolve or cancel, the generator sequence
-continues.
+Alternatively, you may also yield an object, this is useful for stitching together records that may have data at different locations:
+
+```javascript
+function getPost (id) {
+  return fetch(`/posts/${id}`)
+}
+
+function getComments (id) {
+  return fetch(`/posts/${id}/comments`)
+}
+
+function getPostWithComments (id) {
+  return function * (repo) {
+    let { post, comments } = yield {
+      post: repo.push(getPost, id),
+      comments: repo.push(getComments, id)
+    }
+    
+    post.comments = comments
+
+    return post
+  }
+}
+
+repo.push(getBlogPost, 1)
+```
+
+If all actions resolve or cancel, the generator sequence continues.
 
 ### Action status methods are auto-bound
 

--- a/packages/microcosm/src/action.js
+++ b/packages/microcosm/src/action.js
@@ -7,7 +7,7 @@
 import coroutine from './coroutine'
 import Emitter, { type Callback } from './emitter'
 import tag from './tag'
-import { uid } from './utils'
+import { set, uid } from './utils'
 
 type ActionUpdater = (payload?: mixed) => *
 type Revision = { status: string, payload: *, timestamp: number }
@@ -187,8 +187,8 @@ class Action extends Emitter {
    * Set up an action such that it depends on the result of another
    * series of actions.
    */
-  link(actions: Action[] | { [string]: Action }): this {
-    let keys = Object.keys(actions)
+  link(actions: *): this {
+    let keys = Object.keys(Object(actions))
     let outstanding = keys.length
     let answers = Array.isArray(actions) ? [] : {}
 
@@ -208,9 +208,11 @@ class Action extends Emitter {
         }
       }
 
-      action.onDone(onResolve)
-      action.onCancel(onResolve)
-      action.onError(this.reject)
+      action.subscribe({
+        onDone: onResolve,
+        onCancel: onResolve,
+        onError: this.reject
+      })
     })
 
     return this

--- a/packages/microcosm/src/action.js
+++ b/packages/microcosm/src/action.js
@@ -7,7 +7,7 @@
 import coroutine from './coroutine'
 import Emitter, { type Callback } from './emitter'
 import tag from './tag'
-import { set, uid } from './utils'
+import { uid } from './utils'
 
 type ActionUpdater = (payload?: mixed) => *
 type Revision = { status: string, payload: *, timestamp: number }

--- a/packages/microcosm/src/action.js
+++ b/packages/microcosm/src/action.js
@@ -187,17 +187,20 @@ class Action extends Emitter {
    * Set up an action such that it depends on the result of another
    * series of actions.
    */
-  link(actions: Action[]): this {
-    let outstanding = actions.length
-    let answers = []
+  link(actions: Action[] | { [string]: Action }): this {
+    let keys = Object.keys(actions)
+    let outstanding = keys.length
+    let answers = Array.isArray(actions) ? [] : {}
 
-    if (actions.length === 0) {
+    if (keys.length <= 0) {
       return this.resolve(answers)
     }
 
-    actions.forEach(action => {
+    keys.forEach(key => {
+      let action = actions[key]
+
       let onResolve = answer => {
-        answers[actions.indexOf(action)] = answer
+        answers[key] = answer
         outstanding -= 1
 
         if (outstanding <= 0) {

--- a/packages/microcosm/src/utils.js
+++ b/packages/microcosm/src/utils.js
@@ -151,6 +151,13 @@ export function isObject(target: *): boolean {
 }
 
 /**
+ * Is a value a POJO?
+ */
+export function isPlainObject(target: *) {
+  return isObject(target) && target.constructor == Object
+}
+
+/**
  * Is a value a function?
  */
 export function isFunction(target: any): boolean {

--- a/packages/microcosm/test/unit/action/link.test.js
+++ b/packages/microcosm/test/unit/action/link.test.js
@@ -60,4 +60,20 @@ describe('Action link', function() {
 
     expect(action.status).toEqual('reject')
   })
+
+  describe('when given an object', function() {
+    it('returns an object', async function() {
+      let repo = new Microcosm()
+
+      let action = repo.parallel({
+        one: repo.push(() => delay(1, 20)),
+        two: repo.push(() => delay(2, 10)),
+        three: repo.push(() => delay(3, 15))
+      })
+
+      let payload = await action
+
+      expect(payload).toEqual({ one: 1, two: 2, three: 3 })
+    })
+  })
 })

--- a/packages/microcosm/test/unit/middleware/generator-middleware.test.js
+++ b/packages/microcosm/test/unit/middleware/generator-middleware.test.js
@@ -235,4 +235,36 @@ describe('Generator Middleware', function() {
       })
     })
   })
+
+  describe('when yielding an object', function() {
+    it('waits for all items to complete', function() {
+      expect.assertions(2)
+
+      let add = n => n
+      let repo = new Microcosm()
+
+      repo.addDomain('count', {
+        getInitialState() {
+          return 0
+        },
+        register() {
+          return {
+            [add]: (a, b) => a + b
+          }
+        }
+      })
+
+      function testReturnValue() {
+        return function*(repo) {
+          yield { one: repo.push(add, 1), two: repo.push(add, 2) }
+        }
+      }
+
+      repo.push(testReturnValue).onDone(payload => {
+        expect(repo).toHaveState('count', 3)
+
+        expect(payload).toEqual({ one: 1, two: 2 })
+      })
+    })
+  })
 })


### PR DESCRIPTION
This commit updates repo.parallel such that it can accept plain JavaScript objects. In this case, the return payload is an object who's keys match the shape provided.

This also allows generator actions to yield objects

```javascript
function getPost (id) {
  return fetch(`/posts/${id}`)
}

function getComments (id) {
  return fetch(`/posts/${id}/comments`)
}

function getPostWithComments (id) {
  return function * (repo) {
    let { post, comments } = yield { post: repo.push(getPost, id), comments: repo.push(getComments, id) }
    
    post.comments = comments

    return post
  }
}

repo.push(getBlogPost, 1)
```