### PR TITLE
Micromanage inception

### DIFF
--- a/packages/micromanage/README.md
+++ b/packages/micromanage/README.md
@@ -1,0 +1,22 @@
+# Micromanage
+
+Data management in Microcosm is very low level. A developer must manipulate data themselves. Micromanage seeks to increase the level of abstraction when working with data in Microcosm. Through this, it seeks to achieve a few goals:
+
+1. Reduced data management boilerplate
+2. Caching
+3. Queries and better Presenter view modelling
+4. Easier testing and decoupling from API requirements
+
+## Design goals
+
+- Create an "Entity" for each data record
+- Entity properties are lazy computed. Do not build a record on storage, only as needed. This should improve memory efficiency.
+- Entities should pass an equality check if created using the same parameters
+- Entities should be observable
+- No nulls. Ever. Ever.
+  - loading state (record hasn't loaded. we think it exists, but don't know)
+  - complete state (record loaded)
+  - refresh state (have record, refetching)
+  - error state (record failed to load)
+- Entity errors fail with consistent messages. 404, 500, etc, should be easy to report to users
+- Entities generate a unique identity hash code, usable for caching and querying

--- a/packages/micromanage/README.md
+++ b/packages/micromanage/README.md
@@ -20,3 +20,73 @@ Data management in Microcosm is very low level. A developer must manipulate data
   - error state (record failed to load)
 - Entity errors fail with consistent messages. 404, 500, etc, should be easy to report to users
 - Entities generate a unique identity hash code, usable for caching and querying
+
+## API Design thoughts
+
+### Before
+
+```javascript
+import { Domain } from 'microcosm'
+
+function getWidget (id) {
+  return fetch(`/widgets/${id}`).then(res => res.json)
+}
+
+class Widgets extends Domain {
+  getInitialState() {
+    return []
+  }
+  addWidget(widgets, widget) {
+    return widgets.concat(widget)
+  }
+  register() {
+    return {
+      [getWidget]: this.addWidget
+    }
+  }
+}
+
+class WidgetShow extends Presenter {
+  getModel(repo, { id }) {
+    return {
+      widget: repo.domains.widgets.map(widgets => widgets.find(w => w.id === id))
+    }
+  }
+
+  ready(repo, props) {
+    repo.push(getWidget, props.id
+  }
+
+  update(repo, props) {
+    if (props.id !== this.props.id) {
+      repo.push(getWidget, props.id)
+    }
+  }
+}
+```
+
+### After
+
+```javascript
+import { Entity, Collection } from 'micromanage'
+
+class Widget extends Entity {
+  static schema = {
+    id: String,
+    name: String,
+    weight: Number
+  }
+}
+
+class Widgets extends Collection(Widget) {
+  // Intentionally left blank, but you could include your own stuff
+}
+
+class WidgetShow extends Presenter {
+  getModel(repo, { id }) {
+    return {
+      widget: repo.domains.widgets.find(1)
+    }
+  }
+}
+```

--- a/packages/micromanage/package.json
+++ b/packages/micromanage/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "micromanage",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
This PR starts micromanage, what I consider to be the missing piece of Microcosm: a data management and querying layer. Domains work reasonably well enough as data-bags, however I'm not happy with how low level their data management operations are. Consider:

```javascript
import { Domain } from 'microcosm'

function getWidget (id) {
  return fetch(`/widgets/${id}`).then(res => res.json)
}

class Widgets extends Domain {
  getInitialState() {
    return []
  }  
  addWidget(widgets, widget) {
    return widgets.concat(widget)
  }
  register() {
    return {
      [getWidget]: this.addWidget
    }
  }  
}

class WidgetShow extends Presenter {
  getModel(repo, { id }) {
    return {
      widget: repo.domains.widgets.map(widgets => widgets.find(w => w.id === id))
    }
  }

  ready(repo, props) {
    repo.push(getWidget, props.id)
  }

  update(repo, props) {
    if (props.id !== this.props.id) {
      repo.push(getWidget, props.id)
    }
  }
}
```

\* Important: This is the microcosm 13 API.

This is too low level:

- You shouldn't have to concatenate a record to a collection on your own when an action resolves. 
- You also shouldn't have to worry about fetching data if a property of a component has changed, or deal with that state. 
- getModel should be less cumbersome. You should just be able to do something like `repo.domains.widgets.find(props.id)`, or something even shorter.

We can do better. These are not valuable uses of project time. What if this were something like:

```javascript
import { Entity, Collection } from 'micromanage'

class Widget extends Entity {
  static schema = {
    id: String,
    name: String,
    weight: Number
  }
}

class Widgets extends Collection(Widget) {
  // Intentionally left blank, but you could include your own stuff
}

class WidgetShow extends Presenter {
  getModel(repo, { id }) {
    return {
      widget: repo.domains.widgets.find(1)
    }
  }
}
```

Querying for an entity is never null. `repo.domains.widgets.find` above could return:

- A loading state record for the widget
- A widget record
- An error state record for the widget

So here goes! This PR includes an initial outline of what I'd like. It's pretty high level, but I thought I'd send it out for transparency.