### PR TITLE
[micromanage] Add schemas

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   modulePathIgnorePatterns: ['example', 'build'],
   moduleNameMapper: {
     '^microcosm$': `<rootDir>/../microcosm/${isBundled ? 'build' : 'src'}`,
-    '^microcosm-http$': `<rootDir>/../microcosm-http/src/http.js`
+    '^microcosm-http$': `<rootDir>/../microcosm-http/src/http.js`,
+    '^micromanage$': `<rootDir>/../micromanage/${isBundled ? 'build' : 'src'}`
   }
 }

--- a/packages/micromanage/jest.config.js
+++ b/packages/micromanage/jest.config.js
@@ -1,0 +1,8 @@
+const { moduleNameMapper } = require('../../jest.config')
+
+module.exports = {
+  testEnvironment: 'node',
+  collectCoverageFrom: ['src/**/*.js'],
+  modulePathIgnorePatterns: ['<rootDir>/build'],
+  moduleNameMapper: moduleNameMapper
+}

--- a/packages/micromanage/src/entity.js
+++ b/packages/micromanage/src/entity.js
@@ -1,0 +1,32 @@
+import assert from 'assert'
+import { errors, nameOf } from './strings'
+
+export class Entity {
+  static schema = {}
+
+  constructor(params) {
+    assert(
+      this.constructor.hasOwnProperty('schema'),
+      errors.noSchema(nameOf(this))
+    )
+
+    for (var key in this.constructor.schema) {
+      if (params.hasOwnProperty(key)) {
+        this._assign(key, params[key])
+      }
+    }
+  }
+
+  _assign(key, value) {
+    let type = this.constructor.schema[key]
+
+    assert(value != null, errors.nullType(nameOf(this), nameOf(type), key))
+
+    assert(
+      Object.getPrototypeOf(value) === type.prototype,
+      errors.wrongType(nameOf(this), nameOf(type), key, nameOf(value))
+    )
+
+    this[key] = value
+  }
+}

--- a/packages/micromanage/src/index.js
+++ b/packages/micromanage/src/index.js
@@ -1,0 +1,1 @@
+export { Entity } from './entity'

--- a/packages/micromanage/src/strings.js
+++ b/packages/micromanage/src/strings.js
@@ -1,0 +1,24 @@
+function string(content) {
+  return (...values) => {
+    return values.reduce((memo, value) => memo.replace('%s', value), content)
+  }
+}
+
+export function nameOf(value) {
+  switch (typeof value) {
+    case 'function':
+      return value.name
+    default:
+      return value ? value.constructor.name : String(value)
+  }
+}
+
+export const errors = {
+  noSchema: string('Entity "%s" needs a schema.'),
+  wrongType: string(
+    'Entity "%s" expected a %s for key "%s". Instead found %s.'
+  ),
+  nullType: string(
+    'Entity "%s" expected a %s for key "%s". Instead found null.'
+  )
+}

--- a/packages/micromanage/test/entity.test.js
+++ b/packages/micromanage/test/entity.test.js
@@ -1,0 +1,44 @@
+import { Entity } from 'micromanage'
+
+it('must define a schema', () => {
+  class NoSQL extends Entity {}
+
+  expect(() => new NoSQL()).toThrow(/Entity "NoSQL" needs a schema./)
+})
+
+it('filters out keys outside of the schema', () => {
+  class Planet extends Entity {
+    static schema = {
+      name: String
+    }
+  }
+
+  let earth = new Planet({ name: 'Earth', color: 'blue' })
+
+  expect(earth).toHaveProperty('name', 'Earth')
+  expect(earth).not.toHaveProperty('color')
+})
+
+it('fails when a parameter does not match the schema', () => {
+  class Planet extends Entity {
+    static schema = {
+      name: String
+    }
+  }
+
+  expect(() => new Planet({ name: 2 })).toThrow(
+    'Entity "Planet" expected a String for key "name". Instead found Number.'
+  )
+})
+
+it('fails when a parameter is null', () => {
+  class Planet extends Entity {
+    static schema = {
+      name: String
+    }
+  }
+
+  expect(() => new Planet({ name: null })).toThrow(
+    'Entity "Planet" expected a String for key "name". Instead found null.'
+  )
+})


### PR DESCRIPTION
This commit adds an initial draft of schemas. If an entity is created without a schema, it fails. Additionally, if a property does not match the schema, it fails. Essentially:

```javascript
class Planet extends Entity {
  static schema = {
    name: String
  }
}

let earth = new Planet({ name: 'earth' })
let invalid = new Planet({ name: 2 })
 // Raises exception:
// 'Entity "Planet" expected a String for key "name". Instead found Number.'
```

**Is this too strict?**

I like the strictness, but I also know that it would be a bummer for an API to change a string or number field, or decide to return null. I still need to figure out the best approach for that.

One idea is to allow it, with an option to send warnings about schema mismatches in a backchannel. You'd get an alert about the issue, but a user wouldn't see an error.

**Will this hold up?**

This is probably okay for numbers, strings, and booleans. What about dates? 

Instead, we could use JSON schemas:

```javascript
class Planet extends Entity {
  static schema = {
    required: [ "name"],
    name: {
      type: "string",
      description: "name of planet; required."
    }
  }
}
```

Long term, I can see nice interop with React components that generate forms based on schemas:

- https://github.com/mozilla-services/react-jsonschema-form
- https://github.com/jaredpalmer/formik

Or documentation generation:

- https://github.com/cloudflarearchive/json-schema-docs-generator