### PR TITLE
Add license to repo root and reference in readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Viget Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ This project uses [Lerna](https://github.com/lerna/lerna), a way to manage multi
 
 Be sure to check out our [contributing guide](./CONTRIBUTING.md) for instructions on getting started.
 
+## License
+
+Microcosm and [all related packages](./packages/microcosm) are [licensed under MIT](./LICENSE).
+
 ---
 
 <a href="http://code.viget.com">


### PR DESCRIPTION
@g-clef pointed out that we're missing a root-level license. This was an oversight when we moved to a mono-repo approach to manage all of the packages under the microcosm umbrella.

This commit addresses that, fixing #501.