### PR TITLE
[microcosm] Always, synchronously, emit the first observer.next()

### DIFF
--- a/packages/microcosm/src/domain.js
+++ b/packages/microcosm/src/domain.js
@@ -71,6 +71,13 @@ export class Domain<State: any = Object> extends Agent {
   }
 
   receive(action: Subject): void {
+    // Avoid a situation where history dispatches before a domain
+    // is fully set up. Domains move into the "next" state when
+    // construction is finished (getInitialState())
+    if (this.status === 'start') {
+      return
+    }
+
     let next = this._rollforward(action)
 
     if (next !== this.payload) {

--- a/packages/microcosm/src/observable.js
+++ b/packages/microcosm/src/observable.js
@@ -97,6 +97,14 @@ export class Subscription implements Unsubscribable {
     } catch (error) {
       subscriptionObserver.error(error)
 
+      // If an exception is raised in a subscriber and there isn't an
+      // error handler, we raise with the scheduler. This happens for
+      // cases like:
+      //
+      // let obs = new Observable(observer => { throw "Crud" })
+      //
+      // obs.subscribe(next => {}) // Raises an exception with the scheduler
+      // obs.subscribe(next => {}, error => {}) // Doesn't raise
       if (observer.error === noop) {
         scheduler().raise(error)
       }

--- a/packages/microcosm/test/unit/domain/register.test.js
+++ b/packages/microcosm/test/unit/domain/register.test.js
@@ -63,4 +63,38 @@ describe('Domain::register', function() {
 
     expect(repo.state.test).toBe('test')
   })
+
+  it('should have state before an action resolves', async () => {
+    expect.assertions(2)
+
+    let repo = new Microcosm()
+    let action = n => Promise.resolve(n)
+
+    repo.addDomain('test', {
+      getInitialState() {
+        return 'start'
+      },
+      register() {
+        return {
+          [action]: {
+            next: (a, b) => `next: ${b}`,
+            complete: (a, b) => `complete: ${b}`
+          }
+        }
+      }
+    })
+
+    let job = repo.push(action, 2)
+
+    job.subscribe({
+      next() {
+        expect(repo.domains.test.payload).toBe('next: 2')
+      },
+      complete() {
+        expect(repo.domains.test.payload).toBe('complete: 2')
+      }
+    })
+
+    await job
+  })
 })

--- a/packages/microcosm/test/unit/subject-map.test.js
+++ b/packages/microcosm/test/unit/subject-map.test.js
@@ -199,7 +199,7 @@ describe('SubjectMap', function() {
       })
 
       expect(hash).toHaveProperty('payload.now', 1)
-      expect(hash).toHaveProperty('payload.later', undefined)
+      expect(hash).toHaveProperty('payload.later', 1)
 
       await hash
 

--- a/packages/microcosm/test/unit/subject.test.js
+++ b/packages/microcosm/test/unit/subject.test.js
@@ -240,26 +240,17 @@ describe('Subject', function() {
     })
   })
 
-  describe('toString', function() {
-    it('stringifies to its key name', () => {
-      expect(new Subject(null, { key: 'foobar' }).toString()).toBe('foobar')
-    })
-
-    it('stringifies to "subject" when given no key', () => {
-      expect(new Subject(null).toString()).toBe('subject')
-    })
-  })
-
   describe('toJSON', function() {
     it('generates a POJO', () => {
-      let subject = new Subject(true, { key: 'foobar' })
+      let subject = new Subject()
 
+      subject.next(true)
       subject.complete()
 
       expect(subject.toJSON()).toEqual({
+        key: 'subject',
         payload: true,
-        status: 'complete',
-        key: 'foobar'
+        status: 'complete'
       })
     })
   })
@@ -292,20 +283,17 @@ describe('Subject', function() {
       expect(answers).toEqual([0, 2, 4, 6, 8])
     })
 
-    it('starts with the current value', async () => {
+    it('starts with the current value', () => {
       let subject = new Subject()
 
       let double = subject.map(value => value * 2)
       let answers = []
 
       subject.next(5)
-
       double.subscribe(value => answers.push(value))
-
       subject.complete()
 
-      await subject
-
+      // Mapping over a subject should be immediate
       expect(answers).toEqual([10])
     })
 


### PR DESCRIPTION
This PR updates Observable such that the first "next" callback invokes immediately. This is important for Observable::map, particularly when binding data in React. Otherwise, React renders before the scheduler clears the queue for an observable. So you'll end up with something like:


```javascript
class UserShow extends Presenter {
  getModel(repo, { id }) {
    let { users } = repo.domains

    return {
      user: users.map(users => find(users, { id })
    }
  }
  render() {
    console.log(this.model.user) 
    // Always undefined initially because the observable callback is still
    // in the scheduler
  }
}
```

Essentially, this makes it so that you can always get a value immediately, even if the initial payload is empty.