### PR TITLE
Update broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Microcosm is a state management tool for [React](https://github.com/facebook/rea
 ## What you get
 
 - A central place to track all application data
-- [Schedule work with actions](./docs/api/actions.md)
+- [Schedule work with actions](http://code.viget.com/microcosm/api/actions.html)
 - Actions understand Promises out of the box and move through predefined states.
-- Keep loading states out of the data layer. Track action progress using [status callbacks](./docs/api/actions.md#ondonecallback-scope).
-- [Split up application state in large apps](./docs/api/microcosm.md#fork) while still sharing common data
-- [Painless optimistic updates](./docs/recipes/ajax.md)
-- Track changes and handle business logic with [Presenter components](./docs/api/presenter.md)
+- Keep loading states out of the data layer. Track action progress using [status callbacks](http://code.viget.com/microcosm/api/actions.html#ondonecallback-scope).
+- [Split up application state in large apps](http://code.viget.com/microcosm/api/domains.html) while still sharing common data
+- [Painless optimistic updates](http://code.viget.com/microcosm/recipes/ajax.html)
+- Track changes and handle business logic with [Presenter components](http://code.viget.com/microcosm/api/presenter.html)
 - 5.5kb gzipped (~18kb minified)
 
 ## What it looks like


### PR DESCRIPTION
The docs directory appears to have moved, so I've updated the links.

I was unable to find a direct link for `fork` (The link titled 'Split up application state in large apps') but guessed from reading that it was referencing Domains.

<!--
Please make sure to read the contributing Guidelines:
https://github.com/vigetlabs/microcosm/blob/master/CONTRIBUTING.md
-->

**What kind of change does this PR introduce?**

- Documentation

**Does this PR introduce a breaking change?**

- No

If yes, please describe the impact and migration path for existing applications:

**Does this PR fulfill these requirements:**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] All tests are passing
- [ ] `yarn pretty` has been run
- [ ] Commits reference open issues

**Additional Information**

<!-- Anything else you'd like to say about this PR -->
