### PR TITLE
[microcosm] Add flow types for scheduler

### DIFF
--- a/packages/microcosm/src/observable.js
+++ b/packages/microcosm/src/observable.js
@@ -102,7 +102,7 @@ export class Subscription implements Unsubscribable {
       // obs.subscribe(next => {}) // Raises an exception with the scheduler
       // obs.subscribe(next => {}, error => {}) // Doesn't raise
       if (observer.error === noop) {
-        scheduler().raise(error)
+        scheduler()._raise(error)
       }
     }
 

--- a/packages/microcosm/test/setup.js
+++ b/packages/microcosm/test/setup.js
@@ -6,20 +6,20 @@ scheduler().onError(error => {
 })
 
 // Make a strict-only test flag
-it.dev = function(description, test) {
+it.dev = function(...args) {
   if (!process.env.BUNDLED) {
-    return it(description, test)
+    return it(...args)
   }
 
-  return it.skip(description, test)
+  return it.skip(...args)
 }
 
-describe.dev = function(description, suite) {
+describe.dev = function(...args) {
   if (!process.env.BUNDLED) {
-    return describe(description, test)
+    return describe(...args)
   }
 
-  return describe.skip(description, test)
+  return describe.skip(...args)
 }
 
 expect.extend({

--- a/packages/microcosm/test/unit/observable.test.js
+++ b/packages/microcosm/test/unit/observable.test.js
@@ -371,7 +371,7 @@ describe('Observable', function() {
     })
   })
 
-  describe('scheduler error handling', () => {
+  describe.dev('scheduler error handling', () => {
     let raise = null
 
     beforeEach(() => {

--- a/packages/microcosm/test/unit/observable.test.js
+++ b/packages/microcosm/test/unit/observable.test.js
@@ -370,4 +370,27 @@ describe('Observable', function() {
       )
     })
   })
+
+  describe('scheduler error handling', () => {
+    let raise = null
+
+    beforeEach(() => {
+      raise = scheduler()._raise
+      scheduler()._raise = jest.fn()
+    })
+
+    afterEach(() => {
+      scheduler()._raise = raise
+    })
+
+    it('raises a scheduler error on unhandled errors', () => {
+      let failure = new Observable(observer => {
+        throw new Error('Oops')
+      })
+
+      failure.subscribe()
+
+      expect(scheduler()._raise).toHaveBeenCalledWith(new Error('Oops'))
+    })
+  })
 })


### PR DESCRIPTION
**What**

Adds [flow type](https://flow.org/en/) definitions for Microcosm's scheduler.

**Why**

The scheduler is a critical piece of Microcosm 13, and it didn't have any flow type coverage.

Adding flow types uncovered a bug where Observable was accessing the scheduler's error handler from the wrong namespace. This PR additionally adds test coverage for that case.