### PR TITLE
Always reapply a snapshot after toggling

### DIFF
--- a/flow/snapshot.js
+++ b/flow/snapshot.js
@@ -16,5 +16,8 @@ declare type Snapshot = {
   // Last known status of the action associated with this snapshot.
   status: Status,
   // Last known payload of the action associated with this snapshot.
-  payload: any
+  payload: any,
+  // Is the current action disabled? This is important triggering a
+  // state refresh. Enabled actions should always recalculate
+  disabled: boolean
 }

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -126,6 +126,7 @@ class DomainEngine {
         base !== head ||
         // Or the payload is different
         action.payload !== snapshot.payload ||
+        action.disabled !== snapshot.disabled || 
         // or the status is different
         action.status !== snapshot.status
       ) {

--- a/src/domain-engine.js
+++ b/src/domain-engine.js
@@ -126,7 +126,7 @@ class DomainEngine {
         base !== head ||
         // Or the payload is different
         action.payload !== snapshot.payload ||
-        action.disabled !== snapshot.disabled || 
+        action.disabled !== snapshot.disabled ||
         // or the status is different
         action.status !== snapshot.status
       ) {

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -252,6 +252,7 @@ export class Microcosm extends Emitter implements Domain {
     this.snapshots[action.id] = merge(snap, {
       last,
       status: action.status,
+      disabled: action.disabled,
       payload: action.payload
     })
 

--- a/src/microcosm.js
+++ b/src/microcosm.js
@@ -228,7 +228,8 @@ export class Microcosm extends Emitter implements Domain {
       last: this.state,
       next: this.state,
       status: 'inactive',
-      payload: undefined
+      payload: undefined,
+      disabled: action.disabled
     }
 
     this.snapshots[action.id] = snapshot

--- a/test/integration/rollbacks.test.js
+++ b/test/integration/rollbacks.test.js
@@ -252,4 +252,21 @@ describe('rollbacks', function() {
 
     expect(repo).toHaveState('test', false)
   })
+
+  it('can redo actions', () => {
+    const repo = new Microcosm({ maxHistory: Infinity })
+
+    repo.addDomain('test', {
+      getInitialState() {
+        return true
+      }
+    })
+
+    let action = repo.reset({ test: false })
+
+    action.toggle()
+    expect(repo).toHaveState('test', true)
+    action.toggle()
+    expect(repo).toHaveState('test', false)
+  })
 })


### PR DESCRIPTION
This commit fixes a bug where toggling an action would not invalidate snapshot cache state, resulting in an incorrect state:

```javascript
repo.addDomain('test', {
  getInitialState() {
    return true
  }
})

let action = repo.reset({ test: false })

action.toggle()

expect(repo).toHaveState('test', true)
action.toggle()
expect(repo).toHaveState('test', false) // This failed
```

The solution is to track disabled action state as a part of the snapshot, just like the status and payload field.

Resolves:
https://github.com/vigetlabs/microcosm/issues/525